### PR TITLE
Feature/64

### DIFF
--- a/src/components/common/Breadcrumbs.js
+++ b/src/components/common/Breadcrumbs.js
@@ -1,5 +1,6 @@
 import {
   Box,
+  ClickAwayListener,
   IconButton,
   Link,
   MenuItem,
@@ -114,8 +115,11 @@ export const CustomBreadcrumbsWithMenu = ({ breadcrumbs }) => {
   const collapsed = !!breadcrumbs && breadcrumbs.length > 5;
 
   const handleClick = (event) => {
-    if (event) {
+    console.log('running e ===');
+    if (event && anchorEl === null) {
       setAnchorEl(event.currentTarget);
+    } else if (anchorEl !== null) {
+      setAnchorEl(null);
     }
   };
 
@@ -161,15 +165,20 @@ export const CustomBreadcrumbsWithMenu = ({ breadcrumbs }) => {
           placement="bottom"
           aria-labelledby="with-menu-breadcrumbs"
         >
-          {collapsedCrumbs && collapsedCrumbs.length > 1
-            ? collapsedCrumbs.map((crumb) => (
-                <MenuItem onClick={handleClose} key={crumb.id}>
-                  {crumb.text}
-                </MenuItem>
-              ))
-            : null}
+          <ClickAwayListener onClickAway={handleClose}>
+            <Box>
+              {collapsedCrumbs && collapsedCrumbs.length > 1
+                ? collapsedCrumbs.map((crumb) => (
+                    <MenuItem onClick={handleClose} key={crumb.id}>
+                      {crumb.text}
+                    </MenuItem>
+                  ))
+                : null}
+            </Box>
+          </ClickAwayListener>
         </Popper>
-      )}
+      )} 
+
       <Breadcrumbs
         aria-label="breadcrumbs"
         maxItems={_breadcrumbs.length}

--- a/src/components/common/Breadcrumbs.js
+++ b/src/components/common/Breadcrumbs.js
@@ -115,7 +115,6 @@ export const CustomBreadcrumbsWithMenu = ({ breadcrumbs }) => {
   const collapsed = !!breadcrumbs && breadcrumbs.length > 5;
 
   const handleClick = (event) => {
-    console.log('running e ===');
     if (event && anchorEl === null) {
       setAnchorEl(event.currentTarget);
     } else if (anchorEl !== null) {


### PR DESCRIPTION
fix: Breadcrumb popper menu doesn't close

- Breadcrumb menu now closes on outside Click 
-  Three dot menu trigger toggles breadcrumb menu popper 