### PR TITLE
PSYNEU-43 feat: Ignore selection on clicks in the hidden part of the …

### DIFF
--- a/src/client/components/views/editView/MainEdit.js
+++ b/src/client/components/views/editView/MainEdit.js
@@ -91,7 +91,7 @@ class MainEdit extends React.Component {
     if (this.props.modelState === modelState.MODEL_LOADED) {
       this.modelHandler = ModelSingleton.getInstance();
       if (isDetachedMode(this)) {
-          const compositionPath = this.props.compositionOpened.getGraphPath()
+        const compositionPath = this.props.compositionOpened.getGraphPath()
         nodes = this.modelHandler.getMetaGraph().getNodeGraph(compositionPath).getDescendancy();
         links = this.modelHandler.getMetaGraph().getNodeGraph(compositionPath)
             .getDescendancyLinks(nodes, this.modelHandler.getMetaGraph().getLinks());

--- a/src/client/components/views/editView/mechanisms/MechSimple.js
+++ b/src/client/components/views/editView/mechanisms/MechSimple.js
@@ -75,7 +75,6 @@ class MechSimple extends React.Component {
         let clipPath = null
         if(clipData){
             clipPath = clipData.clipPath
-            model.setLocked(isCompletelyOutside(parentNode, model))
         }
 
 

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -2,7 +2,7 @@ import {CallbackTypes} from '@metacell/meta-diagram';
 import ModelSingleton from '../ModelSingleton';
 import {isDetachedMode} from "../utils";
 import {updateCompositionDimensions} from "./utils";
-
+import {isMouseInsideNode} from "../../services/clippingService";
 
 export function handlePostUpdates(event, context) {
     const node = event.entity;
@@ -22,6 +22,12 @@ export function handlePostUpdates(event, context) {
         }
         case CallbackTypes.SELECTION_CHANGED: {
             const newInstance = node.getID();
+            const metaGraph = modelInstance.getMetaGraph()
+            const parent = metaGraph.getParent(node)
+            if(parent && !isMouseInsideNode(context.mousePos, parent)){
+                context.engine.getModel().clearSelection();
+                break;
+            }
             context.props.selectInstance(newInstance);
             break;
         }

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -2,7 +2,7 @@ import {CallbackTypes} from '@metacell/meta-diagram';
 import ModelSingleton from '../ModelSingleton';
 import {isDetachedMode} from "../utils";
 import {updateCompositionDimensions} from "./utils";
-import {isMouseInsideNode} from "../../services/clippingService";
+import {isPositionInsideNode} from "../../services/clippingService";
 
 export function handlePostUpdates(event, context) {
     const node = event.entity;
@@ -24,7 +24,7 @@ export function handlePostUpdates(event, context) {
             const newInstance = node.getID();
             const metaGraph = modelInstance.getMetaGraph()
             const parent = metaGraph.getParent(node)
-            if(parent && !isMouseInsideNode(context.mousePos, parent)){
+            if(parent && !isPositionInsideNode(context.mousePos, parent)){
                 context.engine.getModel().clearSelection();
                 break;
             }

--- a/src/client/services/clippingService.ts
+++ b/src/client/services/clippingService.ts
@@ -223,11 +223,11 @@ export function updateLinkPoints(port: PortModel, link: MetaLinkModel, points: P
 
 /**
  * Checks if the mouse position provided is inside the node or not
- * @param {x: number, y: number} mousePos - The mouse position
+ * @param {x: number, y: number} pos - The position to check.
  * @param {MetaNodeModel} node - The node to check against.
- * @returns {boolean} - Returns true if the mouse position is inside the node
+ * @returns {boolean} - Returns true if the position is inside the node
  */
-export function isMouseInsideNode(mousePos: { x: number; y: number; }, node: MetaNodeModel) {
+export function isPositionInsideNode(pos: { x: number; y: number; }, node: MetaNodeModel) {
     const nodePosition = node.getPosition();
     const nodeBoundingBox = node.getBoundingBox();
 
@@ -238,10 +238,10 @@ export function isMouseInsideNode(mousePos: { x: number; y: number; }, node: Met
     };
 
     return (
-        mousePos.x >= topLeft.x &&
-        mousePos.x <= bottomRight.x &&
-        mousePos.y >= topLeft.y &&
-        mousePos.y <= bottomRight.y
+        pos.x >= topLeft.x &&
+        pos.x <= bottomRight.x &&
+        pos.y >= topLeft.y &&
+        pos.y <= bottomRight.y
     );
 }
 

--- a/src/client/services/clippingService.ts
+++ b/src/client/services/clippingService.ts
@@ -220,3 +220,28 @@ export function updateLinkPoints(port: PortModel, link: MetaLinkModel, points: P
         return outsideData
     }
 }
+
+/**
+ * Checks if the mouse position provided is inside the node or not
+ * @param {x: number, y: number} mousePos - The mouse position
+ * @param {MetaNodeModel} node - The node to check against.
+ * @returns {boolean} - Returns true if the mouse position is inside the node
+ */
+export function isMouseInsideNode(mousePos: { x: number; y: number; }, node: MetaNodeModel) {
+    const nodePosition = node.getPosition();
+    const nodeBoundingBox = node.getBoundingBox();
+
+    const topLeft = nodePosition;
+    const bottomRight = {
+        x: nodePosition.x + nodeBoundingBox.getWidth(),
+        y: nodePosition.y + nodeBoundingBox.getHeight(),
+    };
+
+    return (
+        mousePos.x >= topLeft.x &&
+        mousePos.x <= bottomRight.x &&
+        mousePos.y >= topLeft.y &&
+        mousePos.y <= bottomRight.y
+    );
+}
+


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/PSYNEU-42

- Removes previous lock on completely hidden nodes (no longer needed given the new solution)
- Clears selection when a new node is selected by a click on its hidden part (it clears all selections which should be fine if we only allow one entity to be selected at each moment)
- Adds utility function to understand if a given position is inside a node.

Be aware if the node is already selected clicking on the hidden part of the node won't unselect it. 

https://user-images.githubusercontent.com/19196034/235949049-73d26dbb-e750-476d-b951-9fb1f688e8fb.mp4

