### PR TITLE
Feature/psyneu 49

### DIFF
--- a/src/client/components/views/editView/mechanisms/GenericMechanism.js
+++ b/src/client/components/views/editView/mechanisms/GenericMechanism.js
@@ -89,6 +89,8 @@ class GenericMechanism extends React.Component {
   }
 
   changeVisibility() {
+    this.props.model.isExpanded = !this.state.expanded;
+
     this.setState({expanded: !this.state.expanded});
   }
 

--- a/src/client/components/views/editView/mechanisms/InputOutputNode.js
+++ b/src/client/components/views/editView/mechanisms/InputOutputNode.js
@@ -1,18 +1,21 @@
 import * as React from "react";
 import { Box, Typography } from "@mui/material";
+import {PortWidget} from "@projectstorm/react-diagrams";
 
 class InputOutputNode extends React.Component {
-  render() {
-    const { text, direction } = this.props;
-    const nodeClass = direction === 'right' ? 'block reverse' : 'block';
+    render() {
+        const { text, direction, engine, port } = this.props;
+        const nodeClass = direction === 'right' ? 'block reverse' : 'block';
 
-    return (
-      <Box className={nodeClass}>
-        <Box className="disc" />
-        <Typography>{text}</Typography>
-      </Box>
-    );
-  }
+        return (
+            <Box className={nodeClass}>
+                <PortWidget engine={engine} port={port} className="disc">
+                    <Box/>
+                </PortWidget>
+                <Typography>{text}</Typography>
+            </Box>
+        );
+    }
 }
 
 export default InputOutputNode;

--- a/src/client/components/views/editView/mechanisms/MechMetadata.js
+++ b/src/client/components/views/editView/mechanisms/MechMetadata.js
@@ -20,7 +20,6 @@ const styles = {
 class MechMetadata extends React.Component {
     render() {
         const {classes, model, model: {options}, engine, changeVisibility} = this.props;
-        console.log(classes)
         const functionValues = (label, value) => (
             <Box className="block">
                 <Typography component="label">{label}</Typography>

--- a/src/client/components/views/editView/mechanisms/MechMetadata.js
+++ b/src/client/components/views/editView/mechanisms/MechMetadata.js
@@ -1,30 +1,30 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
-import { withStyles } from "@mui/styles";
+import {withStyles} from "@mui/styles";
 import NodeSelection from "./NodeSelection";
 import InputOutputNode from "./InputOutputNode";
 // import TextField from '@mui/material/TextField';
 import Typography from "@mui/material/Typography";
-import { PortTypes, PortWidget } from "@metacell/meta-diagram";
+import {PortTypes} from "@metacell/meta-diagram";
 import vars from "../../../../assets/styles/variables";
 
 const styles = {
-  textColor: {
-    color: vars.functionTextColor
-  },
-  codeColor: {
-    color: vars.functionCodeColor
+    textColor: {
+        color: vars.functionTextColor
+    },
+    codeColor: {
+        color: vars.functionCodeColor
     }
 };
 
 class MechMetadata extends React.Component {
-  render() {
-    const { classes, model, model: { options }, engine, changeVisibility } = this.props;
-    console.log(classes)
-    const functionValues = (label, value) => (
-      <Box className="block">
-        <Typography component="label">{label}</Typography>
-        {/* <TextField
+    render() {
+        const {classes, model, model: {options}, engine, changeVisibility} = this.props;
+        console.log(classes)
+        const functionValues = (label, value) => (
+            <Box className="block">
+                <Typography component="label">{label}</Typography>
+                {/* <TextField
           id="outlined-multiline-flexible"
           maxRows={4}
           value={value}
@@ -32,77 +32,80 @@ class MechMetadata extends React.Component {
           variant="outlined"
           style={{ zIndex: 11 }}
         /> */}
-        <Typography>{value}</Typography>
-      </Box>
-    )
-
-    return (
-      <Box className={`primary-node rounded ${options.variant}`}>
-        {options.selected && (
-          <NodeSelection node={model} engine={engine} text={"Hide properties"} changeVisibility={changeVisibility} />
-        )}
-          <Box className="primary-node_header">
-            <Box className="icon" />
-            <Typography component="p">
-              {options.name}
-            </Typography>
-          </Box>
-
-          <Box>
-          { options.ports.map(port => {
-            switch (port.getType()) {
-              case PortTypes.INPUT_PORT:
-                return (
-                  <PortWidget key={model.getID() + '_' + port.getId()} engine={engine} port={model.getPort(port.getId())}>
-                    <InputOutputNode text={port.getId()} />
-                  </PortWidget>
-                );
-              default:
-                return <></>
-            }
-          })}
-          </Box>
-
-          <Box className="seprator" />
-
-          <Box className="block-wrapper">
-            {
-              functionValues('Context', '12')
-            }
-            {
-              functionValues('Size', '8.90')
-            }
-            {
-              functionValues('Prefs', '44')
-            }
-            <Box className="block">
-              <Typography component="label">Function</Typography>
-              <Typography className="function">
-                <Typography component="strong" className={classes?.textColor} >
-                  function
-                </Typography>=pnl.<Typography className={classes?.codeColor} component="strong">Logistic</Typography>(gain=1.0, bias=-4)</Typography>
+                <Typography>{value}</Typography>
             </Box>
-          </Box>
+        )
 
-          <Box className="seprator" />
+        return (
+            <Box className={`primary-node rounded ${options.variant}`}>
+                {options.selected && (
+                    <NodeSelection node={model} engine={engine} text={"Hide properties"}
+                                   changeVisibility={changeVisibility}/>
+                )}
+                <Box className="primary-node_header">
+                    <Box className="icon"/>
+                    <Typography component="p">
+                        {options.name}
+                    </Typography>
+                </Box>
 
-          <Box>
-          { options.ports.map(port => {
-            switch (port.getType()) {
-              case PortTypes.OUTPUT_PORT:
-                return (
-                  <PortWidget key={model.getID() + '_' + port.getId()} engine={engine} port={model.getPort(port.getId())}>
-                    <InputOutputNode text={port.getId()} direction="right" />
-                  </PortWidget>
-                );
-              default:
-                return <></>
-            }
-          })}
-          </Box>
-        </Box>
-    );
-  }
+                <Box>
+                    {options.ports.map(port => {
+                        switch (port.getType()) {
+                            case PortTypes.INPUT_PORT:
+                                return (
+                                    <InputOutputNode key={model.getID() + '_' + port.getId()} engine={engine}
+                                                     port={model.getPort(port.getId())} text={port.getId()}/>
+                                );
+                            default:
+                                return <></>
+                        }
+                    })}
+                </Box>
+
+                <Box className="seprator"/>
+
+                <Box className="block-wrapper">
+                    {
+                        functionValues('Context', '12')
+                    }
+                    {
+                        functionValues('Size', '8.90')
+                    }
+                    {
+                        functionValues('Prefs', '44')
+                    }
+                    <Box className="block">
+                        <Typography component="label">Function</Typography>
+                        <Typography className="function">
+                            <Typography component="strong" className={classes?.textColor}>
+                                function
+                            </Typography>=pnl.<Typography className={classes?.codeColor}
+                                                          component="strong">Logistic</Typography>(gain=1.0,
+                            bias=-4)</Typography>
+                    </Box>
+                </Box>
+
+                <Box className="separator"/>
+
+                <Box>
+                    {options.ports.map(port => {
+                        switch (port.getType()) {
+                            case PortTypes.OUTPUT_PORT:
+                                return (
+                                    <InputOutputNode key={model.getID() + '_' + port.getId()} engine={engine}
+                                                     port={model.getPort(port.getId())} text={port.getId()}
+                                                     direction="right"/>
+                                )
+                                    ;
+                            default:
+                                return <></>
+                        }
+                    })}
+                </Box>
+            </Box>
+        );
+    }
 }
 
 export default withStyles(styles)(MechMetadata);

--- a/src/client/components/views/editView/projections/CustomLinkWidget.js
+++ b/src/client/components/views/editView/projections/CustomLinkWidget.js
@@ -294,6 +294,9 @@ export class CustomLinkWidget extends DefaultLinkWidget {
         const targetPort = this.props.link.getTargetPort()
         const node = targetPort.getParent()
         const parentNode = ModelSingleton.getInstance().getMetaGraph().getParent(node);
+        if(!parentNode) {
+            return false
+        }
         const parentNodeBoundingBox = parentNode.getBoundingBox();
         const targetPortPosition = targetPort.getPosition();
 
@@ -343,10 +346,10 @@ export class CustomLinkWidget extends DefaultLinkWidget {
             );
         }
 
-        // we draw an arrow in all situations except when both source and target ports have the same parent and the
-        // target port is fully hidden
-        if (!(this.portsHaveSameParent() && this.isTargetPortHidden())) {
+        // we draw an arrow in all situations except when both source and target ports have the same parent
+        // (excluding undefined as parent) and the target port is fully hidden
 
+        if (!(this.portsHaveSameParent() && this.isTargetPortHidden())) {
             paths.push(
                 this.generateArrow(edgePoint, points[points.length - 2]))
         }

--- a/src/client/components/views/editView/projections/CustomLinkWidget.js
+++ b/src/client/components/views/editView/projections/CustomLinkWidget.js
@@ -283,12 +283,23 @@ export class CustomLinkWidget extends DefaultLinkWidget {
         const sourcePort = link.getSourcePort();
         const targetPort = link.getTargetPort();
 
-        let points = [
-            getEdgePoint(sourcePort.getCenter(), targetPort.getCenter(),
-                sourcePort.getParent().getBoundingBox().getWidth() / 2, link),
-            getEdgePoint(targetPort.getCenter(), sourcePort.getCenter(),
-                targetPort.getParent().getBoundingBox().getWidth() / 2, link)
-        ]
+        const points = [...link.getPoints()]
+        if (!sourcePort.getParent().isExpanded) {
+            // fixme: the generic commented code below is not working properly, we are using a constant for now
+            //const radius = sourcePort.getParent().getBoundingBox().getWidth() / 2
+            const radius = 160 / 2
+
+            points[0] = getEdgePoint(sourcePort.getCenter(), targetPort.getCenter(),
+                radius, link)
+        }
+        if (!targetPort.getParent().isExpanded) {
+            // fixme: the generic commented code below is not working properly, we are using a constant for now
+            //const radius = targetPort.getParent().getBoundingBox().getWidth() / 2
+            const radius = 160 / 2
+
+            points[1] = getEdgePoint(targetPort.getCenter(), sourcePort.getCenter(),
+                radius, link)
+        }
 
         updateLinkPoints(sourcePort.getParent(), points[0]);
         const isTargetPortVisible = updateLinkPoints(targetPort.getParent(), points[1]);
@@ -304,7 +315,7 @@ export class CustomLinkWidget extends DefaultLinkWidget {
                     key={`link-from-${points[j].getID()}-to-${points[j + 1].getID()}`}
                     path={this.generateLinePath(
                         {x: points[j].getX(), y: points[j].getY()},
-                        {x: points[j+1].getX(), y: points[j+1].getY()}
+                        {x: points[j + 1].getX(), y: points[j + 1].getY()}
                     )}
                     {...this.props}
                 />

--- a/src/client/services/clippingService.ts
+++ b/src/client/services/clippingService.ts
@@ -206,7 +206,6 @@ export function getNearestParentPointModel(parent: MetaNodeModel, originalPort: 
  * @param {MetaLinkModel} link - The link to update.
  * @param {PointModel[]} points - The array of points used to define the link path.
  * @param {number} index - The index of the point in the points array to be updated.
- * @returns {DirectionalData | null} - Returns the outside data of the link relative to its parent and the updated points
  */
 
 export function updateLinkPoints(port: PortModel, link: MetaLinkModel, points: PointModel[], index: number) {
@@ -214,9 +213,10 @@ export function updateLinkPoints(port: PortModel, link: MetaLinkModel, points: P
     const parentNode = ModelSingleton.getInstance().getMetaGraph().getParent(node);
     if(parentNode){
         const outsideData = getOutsideData(parentNode, link);
+        // If the node is partially or fully outside the parent node
         if (outsideData && isAnyDirectionOutside(outsideData) && parentNode) {
+            // We connect to the nearest parent point
             points[index] = getNearestParentPointModel(parentNode, port, link);
         }
-        return outsideData
     }
 }

--- a/src/client/services/clippingService.ts
+++ b/src/client/services/clippingService.ts
@@ -2,7 +2,7 @@ import {MetaLinkModel, MetaNodeModel} from "@metacell/meta-diagram";
 import {PointModel, PortModel} from "@projectstorm/react-diagrams-core";
 import {Point} from "@projectstorm/geometry";
 import ModelSingleton from "../model/ModelSingleton";
-import {clipPathBorderBuffer, clipPathHorizontalBorderBuffer} from "../../constants";
+import {clipPathBorderSize} from "../../constants";
 
 
 /**
@@ -170,55 +170,46 @@ export function getClipPath(parent: MetaNodeModel | null, child: MetaNodeModel |
 /**
  * Gets the nearest parent point model based on the original port, considering input/output buffers.
  * @param {MetaNodeModel} parent - The parent node.
- * @param {PortModel} originalPort - The original port associated with the link.
- * @param {any} link - The link associated with the port.
- * @returns {PointModel} - Returns the nearest parent point model.
+ * @param {PortModel} position - The original port associated with the link.
+ * @returns {Point} - Returns the nearest parent point.
  */
-export function getNearestParentPointModel(parent: MetaNodeModel, originalPort: PortModel, link: any) {
-    const bufferSignal = originalPort.getOptions().alignment == 'left' ? -1 : 1
-    let yPos = originalPort.getY()
-    let xPos = originalPort.getX()
+export function getNearestParentPointModel(parent: MetaNodeModel, position: Point) {
+    let yPos = position.y
+    let xPos = position.x
     // port is on the left side of the node
-    if (originalPort.getX() < parent.getX()) {
-        xPos = parent.getX() + clipPathHorizontalBorderBuffer * bufferSignal
+    if (position.x < parent.getX()) {
+        xPos = parent.getX() + clipPathBorderSize
     }
     // port is on the right side of the node
-    if (originalPort.getX() > parent.getX() + parent.width) {
-        xPos = parent.getX()  + parent.width
+    if (position.x > parent.getX() + parent.width) {
+        xPos = parent.getX()  + parent.width - clipPathBorderSize
     }
     // port is on the top of the node
-    if (originalPort.getY() < parent.getY()) {
-        yPos = parent.getY() + clipPathBorderBuffer * bufferSignal
+    if (position.y < parent.getY()) {
+        yPos = parent.getY() + clipPathBorderSize
     }
     // port is on the bottom of the node
-    if (originalPort.getY() > parent.getY() + parent.height) {
-        yPos = parent.getY() + parent.height
+    if (position.y > parent.getY() + parent.height) {
+        yPos = parent.getY() + parent.height - clipPathBorderSize
     }
-    return new PointModel({
-        link: link,
-        position: new Point(xPos, yPos)
-    })
+    return new Point(xPos, yPos)
 }
 
+
 /**
- * Updates the link points based on the provided port and index.
- * @param {PortModel} port - The port associated with the link.
- * @param {MetaLinkModel} link - The link to update.
- * @param {PointModel[]} points - The array of points used to define the link path.
- * @param {number} index - The index of the point in the points array to be updated.
+ * Updates the point position to the nearestParentPoint if the point is outside the parent.
+ * @param {MetaNodeModel} node - The node associated with the link.
+ * @param {PointModel} pointModel - The point to update.
+ * @returns {boolean} - Returns true if the point was updated
  */
 
-export function updateLinkPoints(port: PortModel, link: MetaLinkModel, points: PointModel[], index: number) {
-    const node = port.getParent() as MetaNodeModel
+export function updateLinkPoints(node: MetaNodeModel, pointModel: PointModel) {
     const parentNode = ModelSingleton.getInstance().getMetaGraph().getParent(node);
-    if(parentNode){
-        const outsideData = getOutsideData(parentNode, link);
-        // If the node is partially or fully outside the parent node
-        if (outsideData && isAnyDirectionOutside(outsideData) && parentNode) {
-            // We connect to the nearest parent point
-            points[index] = getNearestParentPointModel(parentNode, port, link);
-        }
+    if(parentNode && !parentNode.getBoundingBox().containsPoint(pointModel.getPosition())){
+        pointModel.setPosition(getNearestParentPointModel(parentNode, pointModel.getPosition()));
+        return true
     }
+    return false
 }
 
 export function getEdgePoint(center: Point, target: Point, radius: number, link: MetaLinkModel) {

--- a/src/client/services/clippingService.ts
+++ b/src/client/services/clippingService.ts
@@ -220,3 +220,23 @@ export function updateLinkPoints(port: PortModel, link: MetaLinkModel, points: P
         }
     }
 }
+
+export function getEdgePoint(center: Point, target: Point, radius: number, link: MetaLinkModel) {
+    // Calculate the direction of the link
+    let dx = target.x - center.x;
+    let dy = target.y - center.y;
+
+    // Normalize the direction to have a length of 1
+    let length = Math.sqrt(dx * dx + dy * dy);
+    dx /= length;
+    dy /= length;
+
+    // Scale the direction by the radius of the node to get the edge point
+    let edgeX = center.x + dx * radius;
+    let edgeY = center.y + dy * radius;
+
+    return new PointModel({
+        link: link,
+        position: new Point(edgeX, edgeY)
+    });
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,5 +34,3 @@ export const snapshotDimensionsLabel = 'snapshotDimensions'
 
 // fixme: we should be getting this from styles
 export const clipPathBorderSize = (0.125 * 25) * 2 // container border size in (rem * pixels per rem) * 2 to work around the corner border radius
-export const clipPathBorderBuffer = 10
-export const clipPathHorizontalBorderBuffer = clipPathBorderBuffer + 2

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,11 @@ code {
 .simple-input-port {
   position:absolute;
   top: 50%;
-  left: 0%;
+  left: 50%;
 }
 
 .simple-output-port {
   position:absolute;
   top: 50%;
-  left: 100%;
+  left: 50%;
 }


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/PSYNEU-49

- Adds isExpanded property to node model
- Moves PortWidget to the InputOutputNode so that the ports in the expanded mode are in the icons instead of the center of the element that contains the icons
- Updates arrow generation so that its easier to maintain the switch between showing arrow or not
- Updates link/projection logic to handle different modes (expanded connects to the port; not expanded connects to the edge of the node)
- Moves ports to the center of the node in non expanded mode


https://github.com/MetaCell/PsyNeuLinkView/assets/19196034/86dea41e-8cb0-4ab2-87ba-6e856f7f1fb6

