### PR TITLE
Feature/psyneu 59

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "start": "react-app-rewired start",
     "start:dev": "REACT_APP_FRONTEND_DEV=true react-app-rewired start",
     "build": "react-app-rewired build",
+    "build:dev": "REACT_APP_FRONTEND_DEV=true react-app-rewired build",
     "test": "react-app-rewired test",
     "test-no-watch": "react-app-rewired test --watchAll=false",
     "eject": "react-app-rewired eject",

--- a/src/client/components/common/Layout.js
+++ b/src/client/components/common/Layout.js
@@ -49,10 +49,11 @@ class Layout extends React.Component {
   }
 
   async componentDidMount() {
-    const envs = await window.api.getInterfaces().PsyneulinkHandler.getCondaEnvs();
 
+      let envs
     if (window.api) {
-      window.api.receive("fromMain", (data) => {
+        envs = await window.api.getInterfaces().PsyneulinkHandler.getCondaEnvs();
+        window.api.receive("fromMain", (data) => {
         messageHandler(data, {
           [messageTypes.OPEN_FILE]: this.props.openFile,
           [messageTypes.LOAD_MODEL]: this.props.loadModel,

--- a/src/client/components/views/editView/MainEdit.js
+++ b/src/client/components/views/editView/MainEdit.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withStyles } from '@mui/styles';
-import { modelState } from '../../../../constants';
+import {fontsize, modelState} from '../../../../constants';
 import UndoIcon from '@mui/icons-material/Undo';
 import { Sidebar } from './rightSidebar/Sidebar';
 import BG from '../../../assets/svg/bg-dotted.svg';
@@ -22,6 +22,8 @@ import {
   closeComposition,
 } from '../../../redux/actions/general';
 import {isDetachedMode} from "../../../model/utils";
+import {updateCompositionDimensions} from "../../../model/graph/utils";
+import {Point} from "@projectstorm/geometry";
 
 const {
   breadcrumbTextColor,
@@ -29,6 +31,11 @@ const {
   headerBorderColor,
   listSelectedTextColor,
 } = vars;
+
+const dialogStyles = {
+    widthOffset: 24.25,
+    heightOffset: 11,
+}
 
 const styles = () => ({
   root: {
@@ -79,6 +86,15 @@ class MainEdit extends React.Component {
 
   componentWillUnmount() {
     this.modelHandler.getMetaGraph().removeListener(this.handleMetaGraphChange);
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    // Updates dimensions of detached composition when it opens
+    if (!this.compositionOpened && this.props.compositionOpened) {
+      let dialogWidth = window.innerWidth - dialogStyles.widthOffset * fontsize;
+      let dialogHeight = window.innerHeight - dialogStyles.heightOffset * fontsize;
+      updateCompositionDimensions(this.props.compositionOpened, {width: dialogWidth, height: dialogHeight}, new Point(0, 0));
+    }
   }
 
   handleMetaGraphChange = (event) => {
@@ -157,9 +173,9 @@ class MainEdit extends React.Component {
                   position: 'fixed',
                   top: 96,
                   left: 60,
-                  width: 'calc(100VW - 24.25rem)',
-                  maxWidth: 'calc(100VW - 24.25rem)',
-                  height: 'calc(100Vh - 11rem)',
+                  width: `calc(100VW - ${dialogStyles.widthOffset}rem)`,
+                  maxWidth: `calc(100VW - ${dialogStyles.widthOffset}rem)`,
+                  height: `calc(100VH - ${dialogStyles.heightOffset}rem)`,
                   border: `2px solid ${dialogBorderColor}`,
                   background: headerBorderColor,
                   borderRadius: '0.75rem',

--- a/src/client/components/views/editView/mechanisms/MechSimple.js
+++ b/src/client/components/views/editView/mechanisms/MechSimple.js
@@ -28,12 +28,14 @@ class MechSimple extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
+        const listenerId = this.getListenerID(this.props.model);
         if (prevState.isMounted !== this.state.isMounted && this.state.isMounted) {
             this.forceUpdate()
         }
-        if (this.prevParentID !== this.getListenerID(this.props.model)) {
+        if (this.prevParentID !== listenerId) {
             this.unregisterListener(this.prevParentID)
             this.registerParentListener()
+            this.prevParentID = listenerId;
         }
         this.updateParentStyle()
     }
@@ -48,11 +50,13 @@ class MechSimple extends React.Component {
         const {model} = this.props;
         const parentNode = ModelSingleton.getInstance().getMetaGraph().getParent(model)
         if (parentNode) {
-            this.listeners[this.getListenerID(model)] = parentNode.registerListener({
+            const listenerId = this.getListenerID(model);
+            this.listeners[listenerId] = parentNode.registerListener({
                 [CallbackTypes.NODE_RESIZED]: (_) => {
                     this.forceUpdate()
                 },
             });
+            this.prevParentID = listenerId;
         }
     }
 

--- a/src/client/components/views/editView/rightSidebar/TreeView/InstanceTreeView.js
+++ b/src/client/components/views/editView/rightSidebar/TreeView/InstanceTreeView.js
@@ -212,16 +212,9 @@ const InstancesTreeView = (props) => {
     setRight(initialRightClickStateCreator());
   }
 
-  // Initialize state in this hook
   useEffect(() => {
-    // Populate tree items state with datasets
-    if (items.length === 0 && datasets.length > 0) {
       setItems(datasets);
-    } else if (datasets.length > 0 && items.length !== datasets.length) {
-      // Update datasets, after adding a new dataset
-      setItems(datasets);
-    }
-  }, [datasets, items.length]);
+  }, [datasets]);
 
   const getTreeItemsFromData = (treeItems) => {
     if (Array.isArray(treeItems) && treeItems.length <= 0) return;

--- a/src/client/model/ModelSingleton.ts
+++ b/src/client/model/ModelSingleton.ts
@@ -53,7 +53,7 @@ export default class ModelSingleton {
         ]);
         // @ts-ignore
         ModelSingleton.metaGraph.addLinks(ModelSingleton.interpreter.getMetaModel()[PNLClasses.PROJECTION]);
-        ModelSingleton.treeModel = this.generateTreeModel();
+        this.updateTreeModel()
     }
 
     static initInstance(initModel: any) {
@@ -88,20 +88,18 @@ export default class ModelSingleton {
         return newNode;
     }
 
-    public updateTreeModel(){
+    public updateTreeModel() {
         ModelSingleton.treeModel = this.generateTreeModel();
     }
 
-    public updateModel(node: MetaNodeModel, newX: number, newY: number, updateGraph = true): any {
-        if (updateGraph) {
-            const pathUpdated = ModelSingleton.metaGraph.updateGraph(
-                node,
-                newX,
-                newY,
-            );
-            if (pathUpdated) {
-                ModelSingleton.treeModel = this.generateTreeModel();
-            }
+    public updateModel(node: MetaNodeModel, newX: number, newY: number): any {
+        const pathUpdated = ModelSingleton.metaGraph.updateGraph(
+            node,
+            newX,
+            newY,
+        );
+        if (pathUpdated) {
+            this.updateTreeModel()
         }
 
     }

--- a/src/client/model/graph/MetaGraph.ts
+++ b/src/client/model/graph/MetaGraph.ts
@@ -117,6 +117,16 @@ export class Graph {
         }
         return false
     }
+
+    updateDescendantsPath(newBasePath: string[]) {
+        this.children.forEach((childGraph) => {
+            const childNode = childGraph.getNode();
+            const newChildPath = [...newBasePath, childNode.getID()];
+
+            childNode.setOption('graphPath', newChildPath);
+            childGraph.updateDescendantsPath(newChildPath);
+        });
+    }
 }
 
 /**
@@ -397,14 +407,39 @@ export class MetaGraph {
      */
     updateNodeInGraph(metaNodeModel: MetaNodeModel, newPath: string[]) {
         const oldPath = metaNodeModel.getGraphPath();
+        let graphToUpdate;
+
+        // If it's a root node, remove it from roots
         if (oldPath.length === 1) {
+            graphToUpdate = this.roots.get(metaNodeModel.getID());
+            if (!graphToUpdate) {
+                throw new Error(`Root not found with ID: ${metaNodeModel.getID()}`);
+            }
             this.roots.delete(oldPath[0]);
         } else {
+            // If it's not a root, remove it from its parent
             let parentGraph = this.findParentNodeGraph(oldPath);
+            graphToUpdate = parentGraph.getChild(metaNodeModel.getID());
+            if (!graphToUpdate) {
+                throw new Error(`Child not found in parent with ID: ${metaNodeModel.getID()}`);
+            }
             parentGraph.deleteChild(metaNodeModel.getID());
         }
+        // Update path
         metaNodeModel.setOption('graphPath', newPath);
-        this.addNode(metaNodeModel);
+
+        // Update path for all descendants
+        graphToUpdate.updateDescendantsPath(newPath);
+
+        // Add node to its new parent
+        if (newPath.length === 1) {
+            this.roots.set(metaNodeModel.getID(), graphToUpdate);
+        } else {
+            const newPathForParent = newPath.slice(0, newPath.length - 1);
+            const newParentGraph = this.getNodeGraph(newPathForParent);
+            newParentGraph.addChild(graphToUpdate);
+        }
+
     }
 
     /**

--- a/src/client/model/graph/MetaGraph.ts
+++ b/src/client/model/graph/MetaGraph.ts
@@ -419,7 +419,6 @@ export class MetaGraph {
                 No need to explicitly call updateChildrenPosition for n children because it will happen automatically in
                 the event listener
              */
-            // @ts-ignore
             const localPosition = n.getLocalPosition()
             n.setPosition(metaNodeModel.getX() + localPosition.x, metaNodeModel.getY() + localPosition.y)
         })
@@ -440,5 +439,24 @@ export class MetaGraph {
      */
     getRoots(): Map<string, Graph> {
         return this.roots;
+    }
+
+    // This method starts the traversal.
+    public updateAllLocalPositions() {
+        this.roots.forEach(root => {
+            this.updateNodeAndChildrenLocalPositions(root, null);
+        });
+    }
+
+    // This method recursively visits each node and updates its local position.
+    private updateNodeAndChildrenLocalPositions(nodeGraph: Graph, parent: MetaNodeModel | null) {
+        const node = nodeGraph.getNode();
+        if (parent !== null) {
+            node.updateLocalPosition(parent);
+        }
+
+        nodeGraph.getChildrenGraphs().forEach(childGraph => {
+            this.updateNodeAndChildrenLocalPositions(childGraph, node);
+        });
     }
 }

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -18,13 +18,15 @@ export function handlePostUpdates(event, context) {
             break;
         }
 
+        case CallbackTypes.ZOOM_UPDATED:
         case CallbackTypes.OFFSET_UPDATED:{
-            // todo: also needs to happen for zoom
             const isDetached = isDetachedMode(context);
             if (isDetached) {
                 const composition = context.props.compositionOpened
-                const { offsetX, offsetY } = event;
-                console.log(offsetX)
+                const engine = context.engine
+                const zoomLevel = engine.getModel().getZoomLevel();
+                const offsetX = engine.getModel().getOffsetX();
+                const offsetY = engine.getModel().getOffsetY();
                 let newPosition = undefined
                if (offsetX > 0 || offsetY < 0){
                    newPosition = composition.position
@@ -39,8 +41,8 @@ export function handlePostUpdates(event, context) {
                    }
                }
                 const newDimensions = {
-                    width: composition.width + Math.abs(offsetX),
-                    height: composition.height + Math.abs(offsetY),
+                    width: (composition.width + Math.abs(offsetX)) * zoomLevel,
+                    height: (composition.height + Math.abs(offsetY)) * zoomLevel,
                 };
 
                 updateCompositionDimensions(composition, newDimensions, newPosition);

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -24,8 +24,20 @@ export function handlePostUpdates(event, context) {
             if (isDetached) {
                 const composition = context.props.compositionOpened
                 const { offsetX, offsetY } = event;
-                // todo: handle position
-                const newPosition = undefined
+                console.log(offsetX)
+                let newPosition = undefined
+               if (offsetX > 0 || offsetY < 0){
+                   newPosition = composition.position
+                   // offset is an accumulative value, we can use it directly as the coordinate value because in
+                   // detached mode, the initial position is (0,0)
+                   // and it doesn't change for positive offset values (the dimensions do)
+                   if (offsetX > 0){
+                       newPosition.x = -offsetX
+                   }
+                   if (offsetY < 0){
+                       newPosition.y = offsetY
+                   }
+               }
                 const newDimensions = {
                     width: composition.width + Math.abs(offsetX),
                     height: composition.height + Math.abs(offsetY),

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -9,14 +9,6 @@ export function handlePostUpdates(event, context) {
     const modelInstance = ModelSingleton.getInstance();
     switch (event.function) {
         case CallbackTypes.POSITION_CHANGED: {
-            const isDetached = isDetachedMode(context);
-            if (isDetached) {
-                const metaGraph = modelInstance.getMetaGraph()
-                const parent = metaGraph.getParent(node)
-                if (parent && parent.getID() === context.props.compositionOpened.getID()) {
-                    updateCompositionDimensions(context.props.compositionOpened, metaGraph.getChildren(context.props.compositionOpened));
-                }
-            }
             modelInstance.updateModel(node, context.mousePos.x, context.mousePos.y);
             break;
         }
@@ -25,6 +17,25 @@ export function handlePostUpdates(event, context) {
             context.props.selectInstance(newInstance);
             break;
         }
+
+        case CallbackTypes.OFFSET_UPDATED:{
+            // todo: also needs to happen for zoom
+            const isDetached = isDetachedMode(context);
+            if (isDetached) {
+                const composition = context.props.compositionOpened
+                const { offsetX, offsetY } = event;
+                // todo: handle position
+                const newPosition = undefined
+                const newDimensions = {
+                    width: composition.width + Math.abs(offsetX),
+                    height: composition.height + Math.abs(offsetY),
+                };
+
+                updateCompositionDimensions(composition, newDimensions, newPosition);
+            }
+            break
+        }
+
         default: {
             console.log(
                 'Function callback type not yet implemented ' + event.function

--- a/src/client/model/graph/utils.js
+++ b/src/client/model/graph/utils.js
@@ -1,5 +1,6 @@
 import {Point} from "@projectstorm/geometry";
 import {clipPathSelectedBorder, clipPathTopAdjustment} from "../../../constants";
+import ModelSingleton from "../ModelSingleton";
 
 function getWrapperDimensions(nodes) {
     if (nodes.length === 0) {
@@ -35,7 +36,21 @@ function getWrapperDimensions(nodes) {
 }
 
 export function updateCompositionDimensions(composition, children) {
+    const metagraph = ModelSingleton.getInstance().getMetaGraph()
     const {width, height, position} = getWrapperDimensions(children);
     composition.position = new Point(position.x, position.y);
     composition.updateDimensions({width, height});
+
+    let ancestor = metagraph.getParent(composition);
+    let updatedWidth = width + 1;
+    let updatedHeight = height + 1;
+
+    while (ancestor) {
+        ancestor.updateDimensions({width: updatedWidth, height: updatedHeight});
+        ancestor = metagraph.getParent(ancestor)
+
+        // Increment dimensions for the next ancestor level.
+        updatedWidth += 1;
+        updatedHeight += 1;
+    }
 }

--- a/src/client/model/graph/utils.js
+++ b/src/client/model/graph/utils.js
@@ -1,6 +1,5 @@
 import {Point} from "@projectstorm/geometry";
 import {clipPathSelectedBorder, clipPathTopAdjustment} from "../../../constants";
-import ModelSingleton from "../ModelSingleton";
 
 function getWrapperDimensions(nodes) {
     if (nodes.length === 0) {
@@ -36,21 +35,7 @@ function getWrapperDimensions(nodes) {
 }
 
 export function updateCompositionDimensions(composition, children) {
-    const metagraph = ModelSingleton.getInstance().getMetaGraph()
     const {width, height, position} = getWrapperDimensions(children);
     composition.position = new Point(position.x, position.y);
     composition.updateDimensions({width, height});
-
-    let ancestor = metagraph.getParent(composition);
-    let updatedWidth = width + 1;
-    let updatedHeight = height + 1;
-
-    while (ancestor) {
-        ancestor.updateDimensions({width: updatedWidth, height: updatedHeight});
-        ancestor = metagraph.getParent(ancestor)
-
-        // Increment dimensions for the next ancestor level.
-        updatedWidth += 1;
-        updatedHeight += 1;
-    }
 }

--- a/src/client/model/graph/utils.js
+++ b/src/client/model/graph/utils.js
@@ -1,5 +1,7 @@
 import {Point} from "@projectstorm/geometry";
 import {clipPathSelectedBorder, clipPathTopAdjustment} from "../../../constants";
+import ModelSingleton from "../ModelSingleton";
+import {CallbackTypes} from "@metacell/meta-diagram";
 
 function getWrapperDimensions(nodes) {
     if (nodes.length === 0) {
@@ -34,8 +36,26 @@ function getWrapperDimensions(nodes) {
     };
 }
 
-export function updateCompositionDimensions(composition, children) {
-    const {width, height, position} = getWrapperDimensions(children);
-    composition.position = new Point(position.x, position.y);
-    composition.updateDimensions({width, height});
+function updateDimensionsAndFireEvent(node, newDimensions) {
+    node.updateDimensions(newDimensions);
+    node.flagUpdate(CallbackTypes.NODE_RESIZED)
+}
+
+export function updateCompositionDimensions(composition, newDimensions, newPosition) {
+    if(newPosition){
+        composition.position = new Point(newPosition.x, newPosition.y);
+    }
+    updateDimensionsAndFireEvent(composition, newDimensions);
+
+
+    const metaGraph = ModelSingleton.getInstance().getMetaGraph()
+    let ancestor = metaGraph.getParent(composition);
+    while (ancestor) {
+        const {width, height, position} = getWrapperDimensions(metaGraph.getChildren(ancestor))
+        if(ancestor.position.x !== position.x || ancestor.position.y !== position.y) {
+            ancestor.position = new Point(position.x, position.y);
+        }
+        updateDimensionsAndFireEvent(ancestor, {width, height});
+        ancestor = metaGraph.getParent(ancestor);
+    }
 }

--- a/src/client/model/utils.js
+++ b/src/client/model/utils.js
@@ -67,6 +67,7 @@ export function generateMetaGraph(metaNodes) {
         const metaNodeModel = mn.toModel()
         metaGraph.addNode(metaNodeModel)
     }
+    metaGraph.updateAllLocalPositions()
     return metaGraph
 }
 

--- a/src/client/redux/middleware/pnlmiddleware.js
+++ b/src/client/redux/middleware/pnlmiddleware.js
@@ -23,34 +23,46 @@ const pnlMiddleware = store => next => action => {
             break;
         }
         case OPEN_COMPOSITION: {
+            const metagraph = ModelSingleton.getInstance().getMetaGraph()
+            const composition = action.data
             // Snapshots dimensions before detached mode is enabled
-            action.data.setOption(snapshotDimensionsLabel, {
-                width: action.data.width,
-                height: action.data.height,
-                position: {x: action.data.position.x, y: action.data.position.y}
+            composition.setOption(snapshotDimensionsLabel, {
+                width: composition.width,
+                height: composition.height,
+                position: {x: composition.position.x, y: composition.position.y}
             })
-            const model = ModelSingleton.getInstance();
-            updateCompositionDimensions(action.data, model.getMetaGraph().getChildren(action.data));
+            let ancestor = metagraph.getParent(composition);
+            while (ancestor) {
+                ancestor.setOption(snapshotDimensionsLabel, {
+                    width: ancestor.width,
+                    height: ancestor.height,
+                    position: {x: ancestor.position.x, y: ancestor.position.y}
+                });
+                ancestor = metagraph.getParent(ancestor);
+            }
+            updateCompositionDimensions(composition, metagraph.getChildren(composition));
             break;
         }
-
         case CLOSE_COMPOSITION: {
-            const composition = action.data
-            const {width, height, position} = composition.getOption(snapshotDimensionsLabel)
+            const metagraph = ModelSingleton.getInstance().getMetaGraph()
+            let composition = action.data
             // Restores original dimensions
-            composition.position = new Point(position.x, position.y);
-            composition.updateDimensions({width, height});
-            composition.setOption('width', width);
-            composition.setOption('height', height);
-            // Clears stored dimensions
-            composition.setOption(snapshotDimensionsLabel, undefined)
+            while (composition) {
+                const {width, height, position} = composition.getOption(snapshotDimensionsLabel)
+                composition.position = new Point(position.x, position.y);
+                composition.updateDimensions({width, height});
+                composition.setOption('width', width);
+                composition.setOption('height', height);
+                // Clears stored dimensions
+                composition.setOption(snapshotDimensionsLabel, undefined)
+                composition = metagraph.getParent(composition);
+            }
             // Clears the selection of all items in the model
-            const diagramModel = composition.parent.parent
+            const diagramModel = action.data.parent.parent
             diagramModel.clearSelection();
             // Recalculates nodes local position
-            const model = ModelSingleton.getInstance();
-            model.getMetaGraph().getChildren(action.data).forEach(node => {
-                node.updateLocalPosition(composition)
+            metagraph.getChildren(action.data).forEach(node => {
+                node.updateLocalPosition(action.data)
             })
             break;
         }

--- a/src/client/redux/middleware/pnlmiddleware.js
+++ b/src/client/redux/middleware/pnlmiddleware.js
@@ -23,34 +23,50 @@ const pnlMiddleware = store => next => action => {
             break;
         }
         case OPEN_COMPOSITION: {
+            const composition = action.data
+            const metaGraph = ModelSingleton.getInstance().getMetaGraph()
             // Snapshots dimensions before detached mode is enabled
-            action.data.setOption(snapshotDimensionsLabel, {
-                width: action.data.width,
-                height: action.data.height,
-                position: {x: action.data.position.x, y: action.data.position.y}
+            composition.setOption(snapshotDimensionsLabel, {
+                width: composition.width,
+                height: composition.height,
+                position: {x: composition.position.x, y: composition.position.y}
             })
-            const model = ModelSingleton.getInstance();
-            updateCompositionDimensions(action.data, model.getMetaGraph().getChildren(action.data));
+            let ancestor = metaGraph.getParent(composition);
+            while (ancestor) {
+                ancestor.setOption(snapshotDimensionsLabel, {
+                    width: ancestor.width,
+                    height: ancestor.height,
+                    position: {x: ancestor.position.x, y: ancestor.position.y}
+                });
+                ancestor = metaGraph.getParent(ancestor);
+            }
+
             break;
         }
 
         case CLOSE_COMPOSITION: {
-            const composition = action.data
-            const {width, height, position} = composition.getOption(snapshotDimensionsLabel)
+            let composition = action.data
+            const metaGraph = ModelSingleton.getInstance().getMetaGraph()
+
             // Restores original dimensions
-            composition.position = new Point(position.x, position.y);
-            composition.updateDimensions({width, height});
-            composition.setOption('width', width);
-            composition.setOption('height', height);
-            // Clears stored dimensions
-            composition.setOption(snapshotDimensionsLabel, undefined)
+            while (composition) {
+                const {width, height, position} = composition.getOption(snapshotDimensionsLabel)
+                composition.position = new Point(position.x, position.y);
+                composition.updateDimensions({width, height});
+                composition.setOption('width', width);
+                composition.setOption('height', height);
+                // Clears stored dimensions
+                composition.setOption(snapshotDimensionsLabel, undefined)
+                composition = metaGraph.getParent(composition)
+            }
+
             // Clears the selection of all items in the model
-            const diagramModel = composition.parent.parent
+            const diagramModel = action.data.parent.parent
             diagramModel.clearSelection();
             // Recalculates nodes local position
             const model = ModelSingleton.getInstance();
             model.getMetaGraph().getChildren(action.data).forEach(node => {
-                node.updateLocalPosition(composition)
+                node.updateLocalPosition(action.data)
             })
             break;
         }

--- a/src/client/resources/model.js
+++ b/src/client/resources/model.js
@@ -7,6 +7,4 @@ const model = {
         [PNLClasses.MECHANISM]: singleNodes.objects
 }
 
-module.exports = {
-        'mockModel': model,
-};
+export const mockModel = model;

--- a/src/client/resources/model.json
+++ b/src/client/resources/model.json
@@ -1,5 +1,5 @@
 {
-    "name": "Composition-0",
+    "name": "Composition-1",
     "directed": true,
     "strict": false,
     "_draw_": [
@@ -22,14 +22,14 @@
                 ],
                 [
                     0.0,
-                    619.0
+                    1046.0
                 ],
                 [
-                    266.0,
-                    619.0
+                    298.0,
+                    1046.0
                 ],
                 [
-                    266.0,
+                    298.0,
                     0.0
                 ]
             ]
@@ -49,27 +49,97 @@
         {
             "op": "T",
             "pt": [
-                133.0,
+                149.0,
                 7.8
             ],
             "align": "c",
-            "width": 82.0,
-            "text": "Composition-0"
+            "width": 103.0,
+            "text": "Composition-1"
         }
     ],
-    "bb": "0,0,266,619",
-    "label": "Composition-0",
+    "bb": "0,0,298,1046",
+    "label": "Composition-1",
     "lheight": "0.21",
-    "lp": "133,11.5",
-    "lwidth": "1.14",
+    "lp": "149,11.5",
+    "lwidth": "1.43",
     "overlap": "False",
     "rankdir": "BT",
     "xdotversion": "1.7",
-    "_subgraph_cnt": 0,
+    "_subgraph_cnt": 1,
     "objects": [
         {
+            "name": "cluster_Composition-0",
+            "_draw_": [
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            8.0,
+                            207.0
+                        ],
+                        [
+                            8.0,
+                            842.0
+                        ],
+                        [
+                            290.0,
+                            842.0
+                        ],
+                        [
+                            290.0,
+                            207.0
+                        ]
+                    ]
+                }
+            ],
+            "_ldraw_": [
+                {
+                    "op": "F",
+                    "size": 14.0,
+                    "face": "Times-Roman"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        149.0,
+                        214.8
+                    ],
+                    "align": "c",
+                    "width": 103.0,
+                    "text": "Composition-0"
+                }
+            ],
+            "bb": "8,207,290,842",
+            "label": "Composition-0",
+            "lheight": "0.21",
+            "lp": "149,218.5",
+            "lwidth": "1.43",
+            "overlap": "False",
+            "rankdir": "BT",
             "_gvid": 0,
-            "name": "input",
+            "nodes": [
+                2,
+                3,
+                5
+            ],
+            "edges": [
+                1,
+                3
+            ]
+        },
+        {
+            "_gvid": 1,
+            "name": "outerInput",
             "_ldraw_": [
                 {
                     "op": "S",
@@ -89,19 +159,19 @@
                     "op": "P",
                     "points": [
                         [
-                            8.0,
+                            18.5,
                             27.0
                         ],
                         [
-                            8.0,
+                            18.5,
                             195.0
                         ],
                         [
-                            258.0,
+                            277.5,
                             195.0
                         ],
                         [
-                            258.0,
+                            277.5,
                             27.0
                         ]
                     ]
@@ -124,19 +194,19 @@
                     "op": "P",
                     "points": [
                         [
-                            14.0,
+                            25.0,
                             141.0
                         ],
                         [
-                            14.0,
+                            25.0,
                             189.0
                         ],
                         [
-                            252.0,
+                            272.0,
                             189.0
                         ],
                         [
-                            252.0,
+                            272.0,
                             141.0
                         ]
                     ]
@@ -159,19 +229,19 @@
                     "op": "P",
                     "points": [
                         [
-                            18.0,
+                            29.0,
                             164.0
                         ],
                         [
-                            18.0,
+                            29.0,
                             185.0
                         ],
                         [
-                            248.0,
+                            268.0,
                             185.0
                         ],
                         [
-                            248.0,
+                            268.0,
                             164.0
                         ]
                     ]
@@ -193,19 +263,19 @@
                     "op": "p",
                     "points": [
                         [
-                            19.0,
+                            30.0,
                             165.0
                         ],
                         [
-                            19.0,
+                            30.0,
                             184.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             184.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             165.0
                         ]
                     ]
@@ -227,7 +297,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        96.0,
+                        111.5,
                         172.4
                     ],
                     "align": "l",
@@ -251,7 +321,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        98.0,
+                        113.5,
                         149.4
                     ],
                     "align": "l",
@@ -271,7 +341,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        14.0,
+                        29.5,
                         116.4
                     ],
                     "align": "l",
@@ -295,7 +365,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        80.0,
+                        95.5,
                         116.4
                     ],
                     "align": "l",
@@ -315,12 +385,12 @@
                 {
                     "op": "T",
                     "pt": [
-                        29.0,
+                        25.0,
                         101.2
                     ],
                     "align": "l",
-                    "width": 40.0,
-                    "text": "input"
+                    "width": 79.0,
+                    "text": "outerInput"
                 },
                 {
                     "op": "S",
@@ -344,19 +414,19 @@
                     "op": "P",
                     "points": [
                         [
-                            89.0,
+                            109.0,
                             86.0
                         ],
                         [
-                            89.0,
+                            109.0,
                             136.0
                         ],
                         [
-                            252.0,
+                            272.0,
                             136.0
                         ],
                         [
-                            252.0,
+                            272.0,
                             86.0
                         ]
                     ]
@@ -378,7 +448,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        93.0,
+                        113.0,
                         108.9
                     ],
                     "align": "l",
@@ -403,19 +473,19 @@
                     "op": "P",
                     "points": [
                         [
-                            189.0,
+                            209.0,
                             90.0
                         ],
                         [
-                            189.0,
+                            209.0,
                             132.0
                         ],
                         [
-                            248.0,
+                            268.0,
                             132.0
                         ],
                         [
-                            248.0,
+                            268.0,
                             90.0
                         ]
                     ]
@@ -437,19 +507,19 @@
                     "op": "p",
                     "points": [
                         [
-                            190.0,
+                            210.0,
                             112.0
                         ],
                         [
-                            190.0,
+                            210.0,
                             131.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             131.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             112.0
                         ]
                     ]
@@ -471,7 +541,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        193.0,
+                        213.0,
                         119.4
                     ],
                     "align": "l",
@@ -491,19 +561,19 @@
                     "op": "p",
                     "points": [
                         [
-                            190.0,
+                            210.0,
                             91.0
                         ],
                         [
-                            190.0,
+                            210.0,
                             110.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             110.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             91.0
                         ]
                     ]
@@ -521,7 +591,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        202.5,
+                        222.5,
                         98.4
                     ],
                     "align": "l",
@@ -550,19 +620,19 @@
                     "op": "P",
                     "points": [
                         [
-                            14.0,
+                            25.0,
                             33.0
                         ],
                         [
-                            14.0,
+                            25.0,
                             81.0
                         ],
                         [
-                            252.0,
+                            272.0,
                             81.0
                         ],
                         [
-                            252.0,
+                            272.0,
                             33.0
                         ]
                     ]
@@ -584,7 +654,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        102.5,
+                        118.0,
                         68.4
                     ],
                     "align": "l",
@@ -609,19 +679,19 @@
                     "op": "P",
                     "points": [
                         [
-                            18.0,
+                            29.0,
                             37.0
                         ],
                         [
-                            18.0,
+                            29.0,
                             58.0
                         ],
                         [
-                            248.0,
+                            268.0,
                             58.0
                         ],
                         [
-                            248.0,
+                            268.0,
                             37.0
                         ]
                     ]
@@ -643,19 +713,19 @@
                     "op": "p",
                     "points": [
                         [
-                            19.0,
+                            30.0,
                             38.0
                         ],
                         [
-                            19.0,
+                            30.0,
                             57.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             57.0
                         ],
                         [
-                            247.0,
+                            267.0,
                             38.0
                         ]
                     ]
@@ -677,7 +747,7 @@
                 {
                     "op": "T",
                     "pt": [
-                        101.0,
+                        116.5,
                         45.4
                     ],
                     "align": "l",
@@ -701,19 +771,19 @@
                     "op": "p",
                     "points": [
                         [
-                            9.5,
+                            20.0,
                             28.5
                         ],
                         [
-                            9.5,
+                            20.0,
                             193.5
                         ],
                         [
-                            256.5,
+                            276.0,
                             193.5
                         ],
                         [
-                            256.5,
+                            276.0,
                             28.5
                         ]
                     ]
@@ -723,16 +793,16 @@
             "fontname": "arial",
             "fontsize": "12",
             "height": "2.4444",
-            "label": "<table border='3' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"input\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >input</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
+            "label": "<table border='3' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"outerInput\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >outerInput</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
             "penwidth": "3",
-            "pos": "133,111",
+            "pos": "148,111",
             "rank": "source",
             "shape": "plaintext",
-            "width": "3.6944"
+            "width": "3.8194"
         },
         {
-            "_gvid": 1,
-            "name": "mid",
+            "_gvid": 2,
+            "name": "input",
             "_ldraw_": [
                 {
                     "op": "S",
@@ -752,20 +822,20 @@
                     "op": "P",
                     "points": [
                         [
-                            10.0,
-                            239.0
+                            24.0,
+                            242.0
                         ],
                         [
-                            10.0,
-                            403.0
+                            24.0,
+                            410.0
                         ],
                         [
-                            256.0,
-                            403.0
+                            274.0,
+                            410.0
                         ],
                         [
-                            256.0,
-                            239.0
+                            274.0,
+                            242.0
                         ]
                     ]
                 },
@@ -787,20 +857,20 @@
                     "op": "P",
                     "points": [
                         [
-                            14.0,
-                            351.0
+                            30.0,
+                            356.0
                         ],
                         [
-                            14.0,
-                            399.0
+                            30.0,
+                            404.0
                         ],
                         [
-                            252.0,
-                            399.0
+                            268.0,
+                            404.0
                         ],
                         [
-                            252.0,
-                            351.0
+                            268.0,
+                            356.0
                         ]
                     ]
                 },
@@ -822,20 +892,20 @@
                     "op": "P",
                     "points": [
                         [
-                            18.0,
-                            374.0
+                            34.0,
+                            379.0
                         ],
                         [
-                            18.0,
-                            395.0
+                            34.0,
+                            400.0
                         ],
                         [
-                            248.0,
-                            395.0
+                            264.0,
+                            400.0
                         ],
                         [
-                            248.0,
-                            374.0
+                            264.0,
+                            379.0
                         ]
                     ]
                 },
@@ -856,20 +926,20 @@
                     "op": "p",
                     "points": [
                         [
-                            19.0,
-                            375.0
+                            35.0,
+                            380.0
                         ],
                         [
-                            19.0,
-                            394.0
+                            35.0,
+                            399.0
                         ],
                         [
-                            247.0,
-                            394.0
+                            263.0,
+                            399.0
                         ],
                         [
-                            247.0,
-                            375.0
+                            263.0,
+                            380.0
                         ]
                     ]
                 },
@@ -890,8 +960,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        96.0,
-                        382.4
+                        112.0,
+                        387.4
                     ],
                     "align": "l",
                     "width": 74.0,
@@ -914,8 +984,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        98.0,
-                        359.4
+                        114.0,
+                        364.4
                     ],
                     "align": "l",
                     "width": 70.0,
@@ -934,8 +1004,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        14.0,
-                        326.4
+                        30.0,
+                        331.4
                     ],
                     "align": "l",
                     "width": 66.0,
@@ -958,8 +1028,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        80.0,
-                        326.4
+                        96.0,
+                        331.4
                     ],
                     "align": "l",
                     "width": 4.0,
@@ -978,12 +1048,12 @@
                 {
                     "op": "T",
                     "pt": [
-                        34.5,
-                        311.2
+                        45.0,
+                        316.2
                     ],
                     "align": "l",
-                    "width": 29.0,
-                    "text": "mid"
+                    "width": 40.0,
+                    "text": "input"
                 },
                 {
                     "op": "S",
@@ -1007,20 +1077,20 @@
                     "op": "P",
                     "points": [
                         [
-                            89.0,
-                            296.0
+                            105.0,
+                            301.0
                         ],
                         [
-                            89.0,
-                            346.0
+                            105.0,
+                            351.0
                         ],
                         [
-                            252.0,
-                            346.0
+                            268.0,
+                            351.0
                         ],
                         [
-                            252.0,
-                            296.0
+                            268.0,
+                            301.0
                         ]
                     ]
                 },
@@ -1041,8 +1111,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        93.0,
-                        318.9
+                        109.0,
+                        323.9
                     ],
                     "align": "l",
                     "width": 90.0,
@@ -1066,20 +1136,20 @@
                     "op": "P",
                     "points": [
                         [
-                            189.0,
-                            300.0
+                            205.0,
+                            305.0
                         ],
                         [
-                            189.0,
-                            342.0
+                            205.0,
+                            347.0
                         ],
                         [
-                            248.0,
-                            342.0
+                            264.0,
+                            347.0
                         ],
                         [
-                            248.0,
-                            300.0
+                            264.0,
+                            305.0
                         ]
                     ]
                 },
@@ -1100,20 +1170,20 @@
                     "op": "p",
                     "points": [
                         [
-                            190.0,
-                            322.0
+                            206.0,
+                            327.0
                         ],
                         [
-                            190.0,
-                            341.0
+                            206.0,
+                            346.0
                         ],
                         [
-                            247.0,
-                            341.0
+                            263.0,
+                            346.0
                         ],
                         [
-                            247.0,
-                            322.0
+                            263.0,
+                            327.0
                         ]
                     ]
                 },
@@ -1134,8 +1204,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        193.0,
-                        329.4
+                        209.0,
+                        334.4
                     ],
                     "align": "l",
                     "width": 51.0,
@@ -1154,20 +1224,20 @@
                     "op": "p",
                     "points": [
                         [
-                            190.0,
-                            301.0
+                            206.0,
+                            306.0
                         ],
                         [
-                            190.0,
-                            320.0
+                            206.0,
+                            325.0
                         ],
                         [
-                            247.0,
-                            320.0
+                            263.0,
+                            325.0
                         ],
                         [
-                            247.0,
-                            301.0
+                            263.0,
+                            306.0
                         ]
                     ]
                 },
@@ -1184,8 +1254,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        202.5,
-                        308.4
+                        218.5,
+                        313.4
                     ],
                     "align": "l",
                     "width": 32.0,
@@ -1213,20 +1283,20 @@
                     "op": "P",
                     "points": [
                         [
-                            14.0,
-                            243.0
+                            30.0,
+                            248.0
                         ],
                         [
-                            14.0,
-                            291.0
+                            30.0,
+                            296.0
                         ],
                         [
-                            252.0,
-                            291.0
+                            268.0,
+                            296.0
                         ],
                         [
-                            252.0,
-                            243.0
+                            268.0,
+                            248.0
                         ]
                     ]
                 },
@@ -1247,8 +1317,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        102.5,
-                        278.4
+                        118.5,
+                        283.4
                     ],
                     "align": "l",
                     "width": 61.0,
@@ -1272,20 +1342,20 @@
                     "op": "P",
                     "points": [
                         [
-                            18.0,
-                            247.0
+                            34.0,
+                            252.0
                         ],
                         [
-                            18.0,
-                            268.0
+                            34.0,
+                            273.0
                         ],
                         [
-                            248.0,
-                            268.0
+                            264.0,
+                            273.0
                         ],
                         [
-                            248.0,
-                            247.0
+                            264.0,
+                            252.0
                         ]
                     ]
                 },
@@ -1306,20 +1376,20 @@
                     "op": "p",
                     "points": [
                         [
-                            19.0,
-                            248.0
+                            35.0,
+                            253.0
                         ],
                         [
-                            19.0,
-                            267.0
+                            35.0,
+                            272.0
                         ],
                         [
-                            247.0,
-                            267.0
+                            263.0,
+                            272.0
                         ],
                         [
-                            247.0,
-                            248.0
+                            263.0,
+                            253.0
                         ]
                     ]
                 },
@@ -1340,8 +1410,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        101.0,
-                        255.4
+                        117.0,
+                        260.4
                     ],
                     "align": "l",
                     "width": 64.0,
@@ -1349,7 +1419,7 @@
                 },
                 {
                     "op": "S",
-                    "style": "setlinewidth(1)"
+                    "style": "setlinewidth(3)"
                 },
                 {
                     "op": "S",
@@ -1358,43 +1428,43 @@
                 {
                     "op": "c",
                     "grad": "none",
-                    "color": "#000000"
+                    "color": "#00ff00"
                 },
                 {
                     "op": "p",
                     "points": [
                         [
-                            10.0,
-                            239.0
+                            25.5,
+                            243.5
                         ],
                         [
-                            10.0,
-                            403.0
+                            25.5,
+                            408.5
                         ],
                         [
-                            256.0,
-                            403.0
+                            272.5,
+                            408.5
                         ],
                         [
-                            256.0,
-                            239.0
+                            272.5,
+                            243.5
                         ]
                     ]
                 }
             ],
-            "color": "black",
+            "color": "green",
             "fontname": "arial",
             "fontsize": "12",
-            "height": "2.3889",
-            "label": "<table border='1' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"mid\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >mid</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
-            "penwidth": "1",
-            "pos": "133,321",
-            "rank": "same",
+            "height": "2.4444",
+            "label": "<table border='3' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"input\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >input</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
+            "penwidth": "3",
+            "pos": "149,326",
+            "rank": "source",
             "shape": "plaintext",
-            "width": "3.6389"
+            "width": "3.6944"
         },
         {
-            "_gvid": 2,
+            "_gvid": 3,
             "name": "output",
             "_ldraw_": [
                 {
@@ -1415,20 +1485,20 @@
                     "op": "P",
                     "points": [
                         [
-                            8.0,
-                            447.0
+                            24.0,
+                            662.0
                         ],
                         [
-                            8.0,
-                            615.0
+                            24.0,
+                            830.0
                         ],
                         [
-                            258.0,
-                            615.0
+                            274.0,
+                            830.0
                         ],
                         [
-                            258.0,
-                            447.0
+                            274.0,
+                            662.0
                         ]
                     ]
                 },
@@ -1450,20 +1520,20 @@
                     "op": "P",
                     "points": [
                         [
-                            14.0,
-                            561.0
+                            30.0,
+                            776.0
                         ],
                         [
-                            14.0,
-                            609.0
+                            30.0,
+                            824.0
                         ],
                         [
-                            252.0,
-                            609.0
+                            268.0,
+                            824.0
                         ],
                         [
-                            252.0,
-                            561.0
+                            268.0,
+                            776.0
                         ]
                     ]
                 },
@@ -1485,20 +1555,20 @@
                     "op": "P",
                     "points": [
                         [
-                            18.0,
-                            584.0
+                            34.0,
+                            799.0
                         ],
                         [
-                            18.0,
-                            605.0
+                            34.0,
+                            820.0
                         ],
                         [
-                            248.0,
-                            605.0
+                            264.0,
+                            820.0
                         ],
                         [
-                            248.0,
-                            584.0
+                            264.0,
+                            799.0
                         ]
                     ]
                 },
@@ -1519,20 +1589,20 @@
                     "op": "p",
                     "points": [
                         [
-                            19.0,
-                            585.0
+                            35.0,
+                            800.0
                         ],
                         [
-                            19.0,
-                            604.0
+                            35.0,
+                            819.0
                         ],
                         [
-                            247.0,
-                            604.0
+                            263.0,
+                            819.0
                         ],
                         [
-                            247.0,
-                            585.0
+                            263.0,
+                            800.0
                         ]
                     ]
                 },
@@ -1553,8 +1623,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        96.0,
-                        592.4
+                        112.0,
+                        807.4
                     ],
                     "align": "l",
                     "width": 74.0,
@@ -1577,8 +1647,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        98.0,
-                        569.4
+                        114.0,
+                        784.4
                     ],
                     "align": "l",
                     "width": 70.0,
@@ -1597,8 +1667,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        14.0,
-                        536.4
+                        30.0,
+                        751.4
                     ],
                     "align": "l",
                     "width": 66.0,
@@ -1621,8 +1691,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        80.0,
-                        536.4
+                        96.0,
+                        751.4
                     ],
                     "align": "l",
                     "width": 4.0,
@@ -1641,8 +1711,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        24.0,
-                        521.2
+                        40.0,
+                        736.2
                     ],
                     "align": "l",
                     "width": 50.0,
@@ -1670,20 +1740,20 @@
                     "op": "P",
                     "points": [
                         [
-                            89.0,
-                            506.0
+                            105.0,
+                            721.0
                         ],
                         [
-                            89.0,
-                            556.0
+                            105.0,
+                            771.0
                         ],
                         [
-                            252.0,
-                            556.0
+                            268.0,
+                            771.0
                         ],
                         [
-                            252.0,
-                            506.0
+                            268.0,
+                            721.0
                         ]
                     ]
                 },
@@ -1704,8 +1774,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        93.0,
-                        528.9
+                        109.0,
+                        743.9
                     ],
                     "align": "l",
                     "width": 90.0,
@@ -1729,20 +1799,20 @@
                     "op": "P",
                     "points": [
                         [
-                            189.0,
-                            510.0
+                            205.0,
+                            725.0
                         ],
                         [
-                            189.0,
-                            552.0
+                            205.0,
+                            767.0
                         ],
                         [
-                            248.0,
-                            552.0
+                            264.0,
+                            767.0
                         ],
                         [
-                            248.0,
-                            510.0
+                            264.0,
+                            725.0
                         ]
                     ]
                 },
@@ -1763,20 +1833,20 @@
                     "op": "p",
                     "points": [
                         [
-                            190.0,
-                            532.0
+                            206.0,
+                            747.0
                         ],
                         [
-                            190.0,
-                            551.0
+                            206.0,
+                            766.0
                         ],
                         [
-                            247.0,
-                            551.0
+                            263.0,
+                            766.0
                         ],
                         [
-                            247.0,
-                            532.0
+                            263.0,
+                            747.0
                         ]
                     ]
                 },
@@ -1797,8 +1867,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        193.0,
-                        539.4
+                        209.0,
+                        754.4
                     ],
                     "align": "l",
                     "width": 51.0,
@@ -1817,20 +1887,20 @@
                     "op": "p",
                     "points": [
                         [
-                            190.0,
-                            511.0
+                            206.0,
+                            726.0
                         ],
                         [
-                            190.0,
-                            530.0
+                            206.0,
+                            745.0
                         ],
                         [
-                            247.0,
-                            530.0
+                            263.0,
+                            745.0
                         ],
                         [
-                            247.0,
-                            511.0
+                            263.0,
+                            726.0
                         ]
                     ]
                 },
@@ -1847,8 +1917,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        202.5,
-                        518.4
+                        218.5,
+                        733.4
                     ],
                     "align": "l",
                     "width": 32.0,
@@ -1876,20 +1946,20 @@
                     "op": "P",
                     "points": [
                         [
-                            14.0,
-                            453.0
+                            30.0,
+                            668.0
                         ],
                         [
-                            14.0,
-                            501.0
+                            30.0,
+                            716.0
                         ],
                         [
-                            252.0,
-                            501.0
+                            268.0,
+                            716.0
                         ],
                         [
-                            252.0,
-                            453.0
+                            268.0,
+                            668.0
                         ]
                     ]
                 },
@@ -1910,8 +1980,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        102.5,
-                        488.4
+                        118.5,
+                        703.4
                     ],
                     "align": "l",
                     "width": 61.0,
@@ -1935,20 +2005,20 @@
                     "op": "P",
                     "points": [
                         [
-                            18.0,
-                            457.0
+                            34.0,
+                            672.0
                         ],
                         [
-                            18.0,
-                            478.0
+                            34.0,
+                            693.0
                         ],
                         [
-                            248.0,
-                            478.0
+                            264.0,
+                            693.0
                         ],
                         [
-                            248.0,
-                            457.0
+                            264.0,
+                            672.0
                         ]
                     ]
                 },
@@ -1969,20 +2039,20 @@
                     "op": "p",
                     "points": [
                         [
-                            19.0,
-                            458.0
+                            35.0,
+                            673.0
                         ],
                         [
-                            19.0,
-                            477.0
+                            35.0,
+                            692.0
                         ],
                         [
-                            247.0,
-                            477.0
+                            263.0,
+                            692.0
                         ],
                         [
-                            247.0,
-                            458.0
+                            263.0,
+                            673.0
                         ]
                     ]
                 },
@@ -2003,8 +2073,8 @@
                 {
                     "op": "T",
                     "pt": [
-                        101.0,
-                        465.4
+                        117.0,
+                        680.4
                     ],
                     "align": "l",
                     "width": 64.0,
@@ -2027,20 +2097,20 @@
                     "op": "p",
                     "points": [
                         [
-                            9.5,
-                            448.5
+                            25.5,
+                            663.5
                         ],
                         [
-                            9.5,
-                            613.5
+                            25.5,
+                            828.5
                         ],
                         [
-                            256.5,
-                            613.5
+                            272.5,
+                            828.5
                         ],
                         [
-                            256.5,
-                            448.5
+                            272.5,
+                            663.5
                         ]
                     ]
                 }
@@ -2051,46 +2121,1295 @@
             "height": "2.4444",
             "label": "<table border='3' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"output\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >output</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
             "penwidth": "3",
-            "pos": "133,531",
+            "pos": "149,746",
             "rank": "max",
             "shape": "plaintext",
             "width": "3.6944"
-        }
-    ],
-    "edges": [
+        },
         {
-            "_gvid": 0,
-            "tail": 0,
-            "head": 1,
-            "_draw_": [
+            "_gvid": 4,
+            "name": "outerOutput",
+            "_ldraw_": [
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fffff0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            11.5,
+                            874.0
+                        ],
+                        [
+                            11.5,
+                            1042.0
+                        ],
+                        [
+                            284.5,
+                            1042.0
+                        ],
+                        [
+                            284.5,
+                            874.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fafad0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            18.0,
+                            988.0
+                        ],
+                        [
+                            18.0,
+                            1036.0
+                        ],
+                        [
+                            279.0,
+                            1036.0
+                        ],
+                        [
+                            279.0,
+                            988.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#eee8aa"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            22.0,
+                            1011.0
+                        ],
+                        [
+                            22.0,
+                            1032.0
+                        ],
+                        [
+                            275.0,
+                            1032.0
+                        ],
+                        [
+                            275.0,
+                            1011.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(2)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            23.0,
+                            1012.0
+                        ],
+                        [
+                            23.0,
+                            1031.0
+                        ],
+                        [
+                            274.0,
+                            1031.0
+                        ],
+                        [
+                            274.0,
+                            1012.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
                 {
                     "op": "c",
                     "grad": "none",
                     "color": "#000000"
                 },
                 {
-                    "op": "b",
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        111.5,
+                        1019.4
+                    ],
+                    "align": "l",
+                    "width": 74.0,
+                    "text": "OutputPort-0"
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 3
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        113.5,
+                        996.4
+                    ],
+                    "align": "l",
+                    "width": 70.0,
+                    "text": "OutputPorts"
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        29.5,
+                        963.4
+                    ],
+                    "align": "l",
+                    "width": 66.0,
+                    "text": "Mechanism"
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        95.5,
+                        963.4
+                    ],
+                    "align": "l",
+                    "width": 4.0,
+                    "text": ":"
+                },
+                {
+                    "op": "F",
+                    "size": 16.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        18.0,
+                        948.2
+                    ],
+                    "align": "l",
+                    "width": 93.0,
+                    "text": "outerOutput"
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(1)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fafad0"
+                },
+                {
+                    "op": "P",
                     "points": [
                         [
-                            133.0,
-                            186.0
+                            116.0,
+                            933.0
                         ],
                         [
-                            133.0,
-                            208.92
+                            116.0,
+                            983.0
                         ],
                         [
-                            133.0,
-                            217.06
+                            279.0,
+                            983.0
                         ],
                         [
-                            133.0,
-                            235.83
+                            279.0,
+                            933.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 3
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        120.0,
+                        955.9
+                    ],
+                    "align": "l",
+                    "width": 90.0,
+                    "text": "ParameterPorts"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#eee8aa"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            216.0,
+                            937.0
+                        ],
+                        [
+                            216.0,
+                            979.0
+                        ],
+                        [
+                            275.0,
+                            979.0
+                        ],
+                        [
+                            275.0,
+                            937.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(2)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            217.0,
+                            959.0
+                        ],
+                        [
+                            217.0,
+                            978.0
+                        ],
+                        [
+                            274.0,
+                            978.0
+                        ],
+                        [
+                            274.0,
+                            959.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        220.0,
+                        966.4
+                    ],
+                    "align": "l",
+                    "width": 51.0,
+                    "text": "intercept"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            217.0,
+                            938.0
+                        ],
+                        [
+                            217.0,
+                            957.0
+                        ],
+                        [
+                            274.0,
+                            957.0
+                        ],
+                        [
+                            274.0,
+                            938.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        229.5,
+                        945.4
+                    ],
+                    "align": "l",
+                    "width": 32.0,
+                    "text": "slope"
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(1)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fafad0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            18.0,
+                            880.0
+                        ],
+                        [
+                            18.0,
+                            928.0
+                        ],
+                        [
+                            279.0,
+                            928.0
+                        ],
+                        [
+                            279.0,
+                            880.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 3
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        118.0,
+                        915.4
+                    ],
+                    "align": "l",
+                    "width": 61.0,
+                    "text": "InputPorts"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#eee8aa"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            22.0,
+                            884.0
+                        ],
+                        [
+                            22.0,
+                            905.0
+                        ],
+                        [
+                            275.0,
+                            905.0
+                        ],
+                        [
+                            275.0,
+                            884.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(2)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            23.0,
+                            885.0
+                        ],
+                        [
+                            23.0,
+                            904.0
+                        ],
+                        [
+                            274.0,
+                            904.0
+                        ],
+                        [
+                            274.0,
+                            885.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        116.5,
+                        892.4
+                    ],
+                    "align": "l",
+                    "width": 64.0,
+                    "text": "InputPort-0"
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(3)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#ff0000"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            13.0,
+                            875.5
+                        ],
+                        [
+                            13.0,
+                            1040.5
+                        ],
+                        [
+                            283.0,
+                            1040.5
+                        ],
+                        [
+                            283.0,
+                            875.5
                         ]
                     ]
                 }
             ],
-            "_hdraw_": [
+            "color": "red",
+            "fontname": "arial",
+            "fontsize": "12",
+            "height": "2.4444",
+            "label": "<table border='3' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"outerOutput\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >outerOutput</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
+            "penwidth": "3",
+            "pos": "148,958",
+            "rank": "max",
+            "shape": "plaintext",
+            "width": "4.0139"
+        },
+        {
+            "_gvid": 5,
+            "name": "mid",
+            "_ldraw_": [
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fffff0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            26.0,
+                            454.0
+                        ],
+                        [
+                            26.0,
+                            618.0
+                        ],
+                        [
+                            272.0,
+                            618.0
+                        ],
+                        [
+                            272.0,
+                            454.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fafad0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            30.0,
+                            566.0
+                        ],
+                        [
+                            30.0,
+                            614.0
+                        ],
+                        [
+                            268.0,
+                            614.0
+                        ],
+                        [
+                            268.0,
+                            566.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#eee8aa"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            34.0,
+                            589.0
+                        ],
+                        [
+                            34.0,
+                            610.0
+                        ],
+                        [
+                            264.0,
+                            610.0
+                        ],
+                        [
+                            264.0,
+                            589.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(2)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            35.0,
+                            590.0
+                        ],
+                        [
+                            35.0,
+                            609.0
+                        ],
+                        [
+                            263.0,
+                            609.0
+                        ],
+                        [
+                            263.0,
+                            590.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        112.0,
+                        597.4
+                    ],
+                    "align": "l",
+                    "width": 74.0,
+                    "text": "OutputPort-0"
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 3
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        114.0,
+                        574.4
+                    ],
+                    "align": "l",
+                    "width": 70.0,
+                    "text": "OutputPorts"
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        30.0,
+                        541.4
+                    ],
+                    "align": "l",
+                    "width": 66.0,
+                    "text": "Mechanism"
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        96.0,
+                        541.4
+                    ],
+                    "align": "l",
+                    "width": 4.0,
+                    "text": ":"
+                },
+                {
+                    "op": "F",
+                    "size": 16.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        50.5,
+                        526.2
+                    ],
+                    "align": "l",
+                    "width": 29.0,
+                    "text": "mid"
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(1)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fafad0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            105.0,
+                            511.0
+                        ],
+                        [
+                            105.0,
+                            561.0
+                        ],
+                        [
+                            268.0,
+                            561.0
+                        ],
+                        [
+                            268.0,
+                            511.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 3
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        109.0,
+                        533.9
+                    ],
+                    "align": "l",
+                    "width": 90.0,
+                    "text": "ParameterPorts"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#eee8aa"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            205.0,
+                            515.0
+                        ],
+                        [
+                            205.0,
+                            557.0
+                        ],
+                        [
+                            264.0,
+                            557.0
+                        ],
+                        [
+                            264.0,
+                            515.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(2)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            206.0,
+                            537.0
+                        ],
+                        [
+                            206.0,
+                            556.0
+                        ],
+                        [
+                            263.0,
+                            556.0
+                        ],
+                        [
+                            263.0,
+                            537.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        209.0,
+                        544.4
+                    ],
+                    "align": "l",
+                    "width": 51.0,
+                    "text": "intercept"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            206.0,
+                            516.0
+                        ],
+                        [
+                            206.0,
+                            535.0
+                        ],
+                        [
+                            263.0,
+                            535.0
+                        ],
+                        [
+                            263.0,
+                            516.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        218.5,
+                        523.4
+                    ],
+                    "align": "l",
+                    "width": 32.0,
+                    "text": "slope"
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(1)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#fafad0"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            30.0,
+                            458.0
+                        ],
+                        [
+                            30.0,
+                            506.0
+                        ],
+                        [
+                            268.0,
+                            506.0
+                        ],
+                        [
+                            268.0,
+                            458.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 3
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        118.5,
+                        493.4
+                    ],
+                    "align": "l",
+                    "width": 61.0,
+                    "text": "InputPorts"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fffffe00"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#eee8aa"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            34.0,
+                            462.0
+                        ],
+                        [
+                            34.0,
+                            483.0
+                        ],
+                        [
+                            264.0,
+                            483.0
+                        ],
+                        [
+                            264.0,
+                            462.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(2)"
+                },
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#fafad2"
+                },
+                {
+                    "op": "p",
+                    "points": [
+                        [
+                            35.0,
+                            463.0
+                        ],
+                        [
+                            35.0,
+                            482.0
+                        ],
+                        [
+                            263.0,
+                            482.0
+                        ],
+                        [
+                            263.0,
+                            463.0
+                        ]
+                    ]
+                },
+                {
+                    "op": "F",
+                    "size": 12.0,
+                    "face": "arial"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "t",
+                    "fontchar": 1
+                },
+                {
+                    "op": "T",
+                    "pt": [
+                        117.0,
+                        470.4
+                    ],
+                    "align": "l",
+                    "width": 64.0,
+                    "text": "InputPort-0"
+                },
+                {
+                    "op": "S",
+                    "style": "setlinewidth(1)"
+                },
                 {
                     "op": "S",
                     "style": "solid"
@@ -2101,40 +3420,42 @@
                     "color": "#000000"
                 },
                 {
-                    "op": "C",
-                    "grad": "none",
-                    "color": "#000000"
-                },
-                {
-                    "op": "P",
+                    "op": "p",
                     "points": [
                         [
-                            129.5,
-                            236.0
+                            26.0,
+                            454.0
                         ],
                         [
-                            133.0,
-                            246.0
+                            26.0,
+                            618.0
                         ],
                         [
-                            136.5,
-                            236.0
+                            272.0,
+                            618.0
+                        ],
+                        [
+                            272.0,
+                            454.0
                         ]
                     ]
                 }
             ],
-            "arrowhead": "normal",
             "color": "black",
             "fontname": "arial",
-            "fontsize": "10",
-            "headport": "InputPort-InputPort-0",
-            "label": "",
+            "fontsize": "12",
+            "height": "2.3889",
+            "label": "<table border='1' cellborder=\"0\" cellspacing=\"1\" bgcolor=\"#FFFFF0\"><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"OutputPort-OutputPort-0\"><b>OutputPort-0</b></td></tr></table></td></tr> <tr><td colspan=\"1\" valign=\"middle\"><b><i>OutputPorts</i></b></td></tr> </table></td></tr><tr><td port=\"mid\" colspan=\"1\"><b><b><i>Mechanism</i></b>:<br/><font point-size=\"16\" >mid</font></b></td><td> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td rowspan=\"1\" valign=\"middle\"><b><i>ParameterPorts</i></b></td> <td> <table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"ParameterPort-intercept\"><b>intercept</b></td></tr><tr><td port=\"ParameterPort-slope\"><b>slope</b></td></tr></table></td></tr></table></td></tr><tr><td colspan=\"2\"> <table border=\"0\" cellborder=\"0\" bgcolor=\"#FAFAD0\"> <tr><td colspan=\"1\" valign=\"middle\"><b><i>InputPorts</i></b></td></tr><tr><td><table border=\"0\" cellborder=\"2\" cellspacing=\"0\" color=\"LIGHTGOLDENRODYELLOW\" bgcolor=\"PALEGOLDENROD\"><tr><td port=\"InputPort-InputPort-0\"><b>InputPort-0</b></td></tr></table></td></tr></table></td></tr></table>",
             "penwidth": "1",
-            "pos": "e,133,246 133,186 133,208.92 133,217.06 133,235.83",
-            "tailport": "OutputPort-OutputPort-0"
-        },
+            "pos": "149,536",
+            "rank": "same",
+            "shape": "plaintext",
+            "width": "3.6389"
+        }
+    ],
+    "edges": [
         {
-            "_gvid": 1,
+            "_gvid": 0,
             "tail": 1,
             "head": 2,
             "_draw_": [
@@ -2147,20 +3468,20 @@
                     "op": "b",
                     "points": [
                         [
-                            133.0,
-                            396.0
+                            149.0,
+                            186.0
                         ],
                         [
-                            133.0,
-                            418.92
+                            149.0,
+                            211.16
                         ],
                         [
-                            133.0,
-                            427.06
+                            149.0,
+                            219.89
                         ],
                         [
-                            133.0,
-                            445.83
+                            149.0,
+                            240.82
                         ]
                     ]
                 }
@@ -2184,16 +3505,16 @@
                     "op": "P",
                     "points": [
                         [
-                            129.5,
-                            446.0
+                            145.5,
+                            241.0
                         ],
                         [
-                            133.0,
-                            456.0
+                            149.0,
+                            251.0
                         ],
                         [
-                            136.5,
-                            446.0
+                            152.5,
+                            241.0
                         ]
                     ]
                 }
@@ -2205,7 +3526,232 @@
             "headport": "InputPort-InputPort-0",
             "label": "",
             "penwidth": "1",
-            "pos": "e,133,456 133,396 133,418.92 133,427.06 133,445.83",
+            "pos": "e,149,251 149,186 149,211.16 149,219.89 149,240.82",
+            "tailport": "OutputPort-OutputPort-0"
+        },
+        {
+            "_gvid": 1,
+            "tail": 2,
+            "head": 5,
+            "_draw_": [
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "b",
+                    "points": [
+                        [
+                            149.0,
+                            401.0
+                        ],
+                        [
+                            149.0,
+                            423.92
+                        ],
+                        [
+                            149.0,
+                            432.06
+                        ],
+                        [
+                            149.0,
+                            450.83
+                        ]
+                    ]
+                }
+            ],
+            "_hdraw_": [
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            145.5,
+                            451.0
+                        ],
+                        [
+                            149.0,
+                            461.0
+                        ],
+                        [
+                            152.5,
+                            451.0
+                        ]
+                    ]
+                }
+            ],
+            "arrowhead": "normal",
+            "color": "black",
+            "fontname": "arial",
+            "fontsize": "10",
+            "headport": "InputPort-InputPort-0",
+            "label": "",
+            "penwidth": "1",
+            "pos": "e,149,461 149,401 149,423.92 149,432.06 149,450.83",
+            "tailport": "OutputPort-OutputPort-0"
+        },
+        {
+            "_gvid": 2,
+            "tail": 3,
+            "head": 4,
+            "_draw_": [
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "b",
+                    "points": [
+                        [
+                            149.0,
+                            821.0
+                        ],
+                        [
+                            149.0,
+                            844.79
+                        ],
+                        [
+                            149.0,
+                            853.17
+                        ],
+                        [
+                            149.0,
+                            872.75
+                        ]
+                    ]
+                }
+            ],
+            "_hdraw_": [
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            145.5,
+                            873.0
+                        ],
+                        [
+                            149.0,
+                            883.0
+                        ],
+                        [
+                            152.5,
+                            873.0
+                        ]
+                    ]
+                }
+            ],
+            "arrowhead": "normal",
+            "color": "black",
+            "fontname": "arial",
+            "fontsize": "10",
+            "headport": "InputPort-InputPort-0",
+            "label": "",
+            "penwidth": "1",
+            "pos": "e,149,883 149,821 149,844.79 149,853.17 149,872.75",
+            "tailport": "OutputPort-OutputPort-0"
+        },
+        {
+            "_gvid": 3,
+            "tail": 5,
+            "head": 3,
+            "_draw_": [
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "b",
+                    "points": [
+                        [
+                            149.0,
+                            611.0
+                        ],
+                        [
+                            149.0,
+                            633.92
+                        ],
+                        [
+                            149.0,
+                            642.06
+                        ],
+                        [
+                            149.0,
+                            660.83
+                        ]
+                    ]
+                }
+            ],
+            "_hdraw_": [
+                {
+                    "op": "S",
+                    "style": "solid"
+                },
+                {
+                    "op": "c",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "C",
+                    "grad": "none",
+                    "color": "#000000"
+                },
+                {
+                    "op": "P",
+                    "points": [
+                        [
+                            145.5,
+                            661.0
+                        ],
+                        [
+                            149.0,
+                            671.0
+                        ],
+                        [
+                            152.5,
+                            661.0
+                        ]
+                    ]
+                }
+            ],
+            "arrowhead": "normal",
+            "color": "black",
+            "fontname": "arial",
+            "fontsize": "10",
+            "headport": "InputPort-InputPort-0",
+            "label": "",
+            "penwidth": "1",
+            "pos": "e,149,671 149,611 149,633.92 149,642.06 149,660.83",
             "tailport": "OutputPort-OutputPort-0"
         }
     ]

--- a/src/client/services/queryService.ts
+++ b/src/client/services/queryService.ts
@@ -22,15 +22,15 @@ export default class QueryService {
                         return '[(InputPort InputPort-0), (ParameterPort intercept), (ParameterPort slope), (OutputPort OutputPort-0)]'
                     case 'single_node':
                         return '[(InputPort InputPort-0), (ParameterPort intercept), (ParameterPort slope), (OutputPort OutputPort-0)]'
+                    default:
+                        return '[(InputPort InputPort-0), (ParameterPort intercept), (ParameterPort slope), (OutputPort OutputPort-0)]';
                 }
-                break;
 
             case PNLClasses.PROJECTION:
                 return '';
             default:
                 return '';
         }
-        return '';
     }
 
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,7 @@ export enum updateStates {
 export const snapshotDimensionsLabel = 'snapshotDimensions'
 
 // fixme: we should be getting this from styles
-const fontsize = 16
+export const fontsize = 16
 export const clipPathParentBorderSize = (0.125 * fontsize) * 2.5 // container border size in (rem * pixels per rem) * 2 to work around the corner border radius
 export const clipPathTopAdjustment = -2.625 * fontsize // top adjustment in (rem * pixels per rem)
 export const clipPathSelectedBorder = 0.09375 * fontsize // selected border size in (rem * pixels per rem)

--- a/test-memory.js
+++ b/test-memory.js
@@ -1,0 +1,45 @@
+// initial page load url: Google Maps
+function url() {
+    return 'http://localhost:3000/';
+}
+
+const elementSelector = '#root > div > div.jss10 > div.jss12.MuiBox-root.css-0 > div.jss16.MuiBox-root.css-0 > div > div > div:nth-child(2) > div > div > div:nth-child(2) > div:nth-child(2)';
+const dragAmount = 200;
+const repetitions = 7;
+
+async function dragLeft(page) {
+    const draggableElement = await page.$(elementSelector);
+    const boundingBox = await draggableElement.boundingBox();
+    const targetX = boundingBox.x - dragAmount;
+
+    await page.mouse.move(boundingBox.x + boundingBox.width / 2, boundingBox.y + boundingBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(targetX, boundingBox.y + boundingBox.height / 2);
+    await page.mouse.up();
+}
+
+async function dragRight(page) {
+    const draggableElement = await page.$(elementSelector);
+    const boundingBox = await draggableElement.boundingBox();
+    const targetX = boundingBox.x + boundingBox.width + dragAmount;
+
+    await page.mouse.move(boundingBox.x + boundingBox.width / 2, boundingBox.y + boundingBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(targetX, boundingBox.y + boundingBox.height / 2);
+    await page.mouse.up();
+}
+
+async function action(page) {
+    for(let i = 0; i < repetitions; i++) {
+        await dragLeft(page);
+        await page.waitForTimeout(1000);
+        await dragRight(page);
+        await page.waitForTimeout(1000);
+        await page.evaluate(() => {
+            console.log(i);
+        });
+    }
+}
+
+
+module.exports = {action, url};

--- a/test-memory.js
+++ b/test-memory.js
@@ -35,9 +35,6 @@ async function action(page) {
         await page.waitForTimeout(1000);
         await dragRight(page);
         await page.waitForTimeout(1000);
-        await page.evaluate(() => {
-            console.log(i);
-        });
     }
 }
 


### PR DESCRIPTION
Depends on https://github.com/MetaCell/meta-diagram/pull/49

Closes https://metacell.atlassian.net/browse/PSYNEU-59

- Sets the composition opened dimensions to full width of the dialog / page and position to (0,0) when detached mode is set
- Updates right side tree viewer logic to use dataset prop as source of truth
- Removes, no longer needed, updateGraph flag, from MetaGraph. Graph is always updated, it just happens that we set everything prior so that we only keep the changes on the current node or children.
- Fixes update graph for nested compositions (moves the subgraph instead of deleting it and creating it back without the children as previously done by mistake; updates the graphPath of all children).
- Fixes a problem with the misuse of localPosition vs position in nested composition by calculating the localposition attribute after the first render instead of using the position by default.
- Updates event handler to deal with canvas drag and zoom to update the composition position and dimensions in detached mode (Updating the dimensions of a composition will now also update the dimensions of its ancestors)
- Stores and (restores on return of detached mode) the composition and its ancestors dimensions and positions
- Uses a new nested model for demonstration purposes


https://github.com/MetaCell/PsyNeuLinkView/assets/19196034/05641757-8929-4e4a-b036-5cb0849b3d05

