### PR TITLE
Feature/psyneu 75

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,7 +125,3 @@
 .circle-port:hover{
 	background: mediumpurple;
 }
-
-.node {
-  z-index: 9999
-}

--- a/src/client/components/views/editView/compositions/Composition.js
+++ b/src/client/components/views/editView/compositions/Composition.js
@@ -6,6 +6,7 @@ import { Box, Chip } from "@mui/material";
 import vars from "../../../../assets/styles/variables";
 import MORE_OPTION from "../../../../assets/svg/option.svg"
 import { openComposition } from "../../../../redux/actions/general";
+import {resizeChangedPositionOption} from "../../../../../constants";
 
 const {
   chipBorderColor,
@@ -179,12 +180,16 @@ class Composition extends React.Component {
               }
             }}
             onResizeStop={(e, direction, ref, delta, position) => {
-              const chipHeight = Array.from(ref.childNodes).find((child) => child.className.includes('MuiChip-root')).clientHeight * (this.props.engine.getModel().getZoomLevel() / 100) * 2;
+              const chipHeight = Array.from(ref.childNodes).find((child) =>
+                  child.className.includes('MuiChip-root')).clientHeight * (this.props.engine.getModel().getZoomLevel() / 100) * 2;
               if (this.state.xUpdated && this.state.yUpdated === false) {
-                this.props.model.setPosition(parseFloat(this.state.x), this.props.model.getPosition().y);
+                this.props.model.setOption(resizeChangedPositionOption, true, false);
+                this.props.model.setPosition(parseFloat(this.state.x), this.props.model.getPosition().y)
               } else if (this.state.yUpdated && this.state.xUpdated === false) {
+                this.props.model.setOption(resizeChangedPositionOption, true, false);
                 this.props.model.setPosition(this.props.model.getPosition().x, parseFloat(this.state.y) - chipHeight);
               } else if (this.state.xUpdated && this.state.yUpdated) {
+                this.props.model.setOption(resizeChangedPositionOption, true, false);
                 this.props.model.setPosition(parseFloat(this.state.x), parseFloat(this.state.y) - chipHeight);
               }
               this.props.model.updateSize(this.state.width, this.state.height);

--- a/src/client/components/views/editView/mechanisms/shared/MechSimple.js
+++ b/src/client/components/views/editView/mechanisms/shared/MechSimple.js
@@ -25,6 +25,12 @@ class MechSimple extends React.Component {
   componentDidMount() {
     this.registerParentListener();
     this.setState({ isMounted: true });
+    this.setZIndex();
+  }
+
+  setZIndex() {
+    const parentElement = this.elementRef.current.parentElement;
+    parentElement.style.zIndex = '10';
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
@@ -78,6 +84,8 @@ class MechSimple extends React.Component {
     }
   }
 
+  // The parent element refers to the html element that wraps the mechanism
+  // For all effects it is still the part of the mechanism
   updateParentStyle() {
     const parentElement = this.elementRef.current.parentElement;
     if (this.clipPath) {

--- a/src/client/model/graph/MetaGraph.ts
+++ b/src/client/model/graph/MetaGraph.ts
@@ -368,7 +368,16 @@ export class MetaGraph {
      * @returns {MetaNodeModel | undefined} - The parent node if found, undefined otherwise.
      */
     getDeepestCompositionAtPoint(cursorX: number, cursorY: number, metaNodeModel: MetaNodeModel): MetaNodeModel | undefined {
-        return this._getDeepestCompositionAtPointAux(cursorX, cursorY, Array.from(this.roots.values()), metaNodeModel);
+        const parent = this.getParent(metaNodeModel);
+
+        if (parent && parent.getBoundingBox().containsPoint(new Point(cursorX, cursorY))) {
+            const parentGraph = this.getNodeGraph(parent.getGraphPath())
+            return this._getDeepestCompositionAtPointAux(cursorX, cursorY,
+                Array.from(parentGraph.getChildrenGraphs().values()), metaNodeModel) || parent;
+        } else {
+            return this._getDeepestCompositionAtPointAux(cursorX, cursorY,
+                Array.from(this.roots.values()), metaNodeModel);
+        }
     }
 
     _getDeepestCompositionAtPointAux(cursorX: number, cursorY: number, graphs: Graph[], metaNodeModel: MetaNodeModel): MetaNodeModel | undefined {
@@ -384,7 +393,7 @@ export class MetaGraph {
                 continue;
             }
 
-            // Skip itself (it can't move to itself)
+            // If the node is metaNodeModel and metaNodeModel is a composition, skip it
             if (node.getID() === metaNodeModel.getID()) {
                 continue;
             }
@@ -413,7 +422,6 @@ export class MetaGraph {
 
         return deepestComposition;
     }
-
 
 
     /**

--- a/src/client/model/graph/MetaGraph.ts
+++ b/src/client/model/graph/MetaGraph.ts
@@ -383,6 +383,12 @@ export class MetaGraph {
             if (node.options.pnlClass !== PNLClasses.COMPOSITION) {
                 continue;
             }
+
+            // Skip itself (it can't move to itself)
+            if (node.getID() === metaNodeModel.getID()) {
+                continue;
+            }
+
             if (node.getBoundingBox().containsPoint(new Point(cursorX, cursorY))) {
                 // If the current node is the parent of the metaNodeModel, we'll only explore that branch
                 if (node.getID() === parentId) {

--- a/src/client/model/graph/MetaGraph.ts
+++ b/src/client/model/graph/MetaGraph.ts
@@ -1,4 +1,4 @@
-import {PNLClasses} from "../../../constants";
+import {PNLClasses, resizeChangedPositionOption} from "../../../constants";
 import {MetaLink, MetaNodeModel, MetaLinkModel} from "@metacell/meta-diagram"
 import {Point} from "@projectstorm/geometry";
 import {MetaGraphEventTypes} from "./eventsHandler";
@@ -342,8 +342,15 @@ export class MetaGraph {
      * @param {MetaNodeModel} metaNodeModel - The MetaNodeModel whose position changed.
      */
     handleNodePositionChanged(metaNodeModel: MetaNodeModel) {
-        // Update children position (children should move the same delta as node)
-        this.updateChildrenPosition(metaNodeModel)
+        if(metaNodeModel.getOption(resizeChangedPositionOption)){
+            // Update children local position (children shouldn't move but rather accept the new relative position to the parent)
+            this.updateChildrenLocalPosition(metaNodeModel)
+        }else{
+            // Update children position (children should move the same delta as node)
+            this.updateChildrenPosition(metaNodeModel)
+
+        }
+        metaNodeModel.setOption(resizeChangedPositionOption, undefined, false);
         //  Update local position / relative position to the parent
         this.updateNodeLocalPosition(metaNodeModel)
     }
@@ -457,6 +464,18 @@ export class MetaGraph {
              */
             const localPosition = n.getLocalPosition()
             n.setPosition(metaNodeModel.getX() + localPosition.x, metaNodeModel.getY() + localPosition.y)
+        })
+    }
+
+    /**
+     * Updates the local positions of all children nodes relative to the given node.
+     * @param {MetaNodeModel} metaNodeModel - The MetaNodeModel whose children's positions should be updated.
+     */
+    private updateChildrenLocalPosition(metaNodeModel: MetaNodeModel) {
+        const children = this.getChildren(metaNodeModel);
+
+        children.forEach(n => {
+            n.updateLocalPosition(metaNodeModel)
         })
     }
 

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -7,6 +7,7 @@ import {updateCompositionDimensions} from "./utils";
 export function handlePostUpdates(event, context) {
     const node = event.entity;
     const modelInstance = ModelSingleton.getInstance();
+    const defaultZoomLevel = 100;
     switch (event.function) {
         case CallbackTypes.POSITION_CHANGED: {
             modelInstance.updateModel(node, context.mousePos.x, context.mousePos.y);
@@ -30,14 +31,11 @@ export function handlePostUpdates(event, context) {
                 let newPosition = undefined
                if (offsetX > 0 || offsetY > 0){
                    newPosition = composition.position
-                   // offset is an accumulative value, we can use it directly as the coordinate value because in
-                   // detached mode, the initial position is (0,0)
-                   // and it doesn't change for positive offset values (the dimensions do)
                    if (offsetX > 0){
-                       newPosition.x = -offsetX
+                       newPosition.x = -offsetX * defaultZoomLevel/zoomLevel
                    }
                    if (offsetY > 0){
-                       newPosition.y = -offsetY
+                       newPosition.y = -offsetY * defaultZoomLevel/zoomLevel
                    }
                }
                 const newDimensions = {
@@ -46,6 +44,8 @@ export function handlePostUpdates(event, context) {
                 };
 
                 updateCompositionDimensions(composition, newDimensions, newPosition);
+                console.log(zoomLevel)
+                console.log(composition.position)
             }
             break
         }

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -44,8 +44,6 @@ export function handlePostUpdates(event, context) {
                 };
 
                 updateCompositionDimensions(composition, newDimensions, newPosition);
-                console.log(zoomLevel)
-                console.log(composition.position)
             }
             break
         }

--- a/src/client/model/graph/eventsHandler.js
+++ b/src/client/model/graph/eventsHandler.js
@@ -28,7 +28,7 @@ export function handlePostUpdates(event, context) {
                 const offsetX = engine.getModel().getOffsetX();
                 const offsetY = engine.getModel().getOffsetY();
                 let newPosition = undefined
-               if (offsetX > 0 || offsetY < 0){
+               if (offsetX > 0 || offsetY > 0){
                    newPosition = composition.position
                    // offset is an accumulative value, we can use it directly as the coordinate value because in
                    // detached mode, the initial position is (0,0)
@@ -36,8 +36,8 @@ export function handlePostUpdates(event, context) {
                    if (offsetX > 0){
                        newPosition.x = -offsetX
                    }
-                   if (offsetY < 0){
-                       newPosition.y = offsetY
+                   if (offsetY > 0){
+                       newPosition.y = -offsetY
                    }
                }
                 const newDimensions = {

--- a/src/client/model/graph/utils.js
+++ b/src/client/model/graph/utils.js
@@ -59,3 +59,20 @@ export function updateCompositionDimensions(composition, newDimensions, newPosit
         ancestor = metaGraph.getParent(ancestor);
     }
 }
+
+/**
+ * Finds the new path for the given node based on the current parent and cursor coordinates.
+ * @param {MetaNodeModel} metaNodeModel - The MetaNodeModel to find the new path for.
+ * @param {MetaNodeModel | undefined} parent - The current parent node, or undefined if no parent.
+ * @returns {string[]} - The new path for the node as an array of strings.
+ */
+export function getNewPath(metaNodeModel, parent) {
+    if(parent && parent.getID() === metaNodeModel.getID()){
+        return [metaNodeModel.getID()];
+    }
+    return [...parent?.getGraphPath() || [], metaNodeModel.getID()];
+}
+
+export function arePathsDifferent(metaNodeModel, newPath) {
+    return metaNodeModel.getGraphPath().join().toString() !== newPath.join().toString();
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,7 @@ export enum updateStates {
   UPDATE_IN_PROGRESS = 'update_in_progress',
 }
 
-export const snapshotPositionLabel = 'snapshotPosition';
+export const resizeChangedPositionOption = 'resizeChangedPosition';
 
 // fixme: we should be getting this from styles
 // container border size in (rem * pixels per rem) * 2 to work around the corner border radius
@@ -82,3 +82,4 @@ export const fontsize = 16
 export const clipPathParentBorderSize = (0.125 * fontsize) * 2.5 // container border size in (rem * pixels per rem) * 2 to work around the corner border radius
 export const clipPathTopAdjustment = -2.625 * fontsize // top adjustment in (rem * pixels per rem)
 export const clipPathSelectedBorder = 0.09375 * fontsize // selected border size in (rem * pixels per rem)
+


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/PSYNEU-75

- Removes default z-index (9999) to nodes (mechanisms and compositions) and sets it only on the mechanisms to 10. (mechanisms should be drawn on top of compositions, always)
- Adds resizeChangedPositionOption flag to understand if we should move children of composition or not (in case we don't we update the local position)
- Changes algorithm responsible to update the graph. It now iterates over the full graph to detect which compositions are present at the cursor position and chooses the one at the deepest level. If the current parent composition is one of the compositions the cursor position 'touches' that branch is the only one selected to explore.


https://github.com/MetaCell/PsyNeuLinkView/assets/19196034/a242eb78-7986-4362-a199-d5c46c24c820


