### PR TITLE
Fixes mac script 

### DIFF
--- a/package/scripts/linux_installer.sh
+++ b/package/scripts/linux_installer.sh
@@ -11,25 +11,32 @@ check_last_command () {
     fi
 }
 
+# Variables
+APP_NAME="PsyneulinkViewer"          # Name of the application
+SYMLINK_PATH="psyneulinkviewer"      # Symlink to the application you want to launch
+CONDA_ENV=$PSYNEULINK_ENV            # Conda environment to activate if none is active
+ICON_PATH="/usr/local/bin/psyneulinkviewer-linux-x64/resources/app/build/logo.png"    # Path to the custom icon
+DESKTOP_FILE="$HOME/Desktop/$APP_NAME.desktop"     # Path where the desktop shortcut will be created
+
+rm -f "$DESKTOP_FILE"
+
+# Cleanup existing installations of psneulinkviewer
+rm -rf "/usr/local/bin/psyneulinkviewer-linux-x64/" 
+rm -rf "/usr/local/bin/psyneulinkviewer" 
+# Kill any existing rpc_server instances
+ps aux | grep rpc_server | grep -v grep | awk '{print $2}' | xargs kill -9
+
 pip uninstall psyneulinkviewer && pip cache purge
 pip install -vv psyneulinkviewer --break-system-packages --use-pep517 && . ~/.profile && sudo chown root:root /usr/local/bin/psyneulinkviewer-linux-x64/chrome-sandbox && sudo chmod 4755 /usr/local/bin/psyneulinkviewer-linux-x64/chrome-sandbox
 
-# Variables
-APP_NAME="PsyneulinkViewer"                                  # Name of the application
-SYMLINK_PATH="psyneulinkviewer"           # Symlink to the application you want to launch
-CONDA_ENV=$PSYNEULINK_ENV                                  # Conda environment to activate if none is active
-ICON_PATH="/usr/local/bin/psyneulinkviewer-linux-x64/resources/app/build/logo.png"                 # Path to the custom icon
-DESKTOP_FILE="$HOME/Desktop/$APP_NAME.desktop"     # Path where the desktop shortcut will be created
-
 # Creating the .desktop file for the application
-rm -f "$DESKTOP_FILE"
 echo "[Desktop Entry]" > "$DESKTOP_FILE"
 echo "Version=1.0" >> "$DESKTOP_FILE"
 echo "Name=$APP_NAME" >> "$DESKTOP_FILE"
 
 # Create the Exec command: Check if conda environment is active, if not activate the specified one
 echo "Exec=bash -c '. ~/miniconda3/etc/profile.d/conda.sh && \
-conda activate $CONDA_ENV && \
+conda activate $PSYNEULINK_ENV && \
 $SYMLINK_PATH'" >> "$DESKTOP_FILE"
 
 # Set the custom icon

--- a/package/scripts/mac_installer.sh
+++ b/package/scripts/mac_installer.sh
@@ -23,9 +23,9 @@ COMMAND_FILE_PATH="$APP_SHORTCUT_PATH/Contents/MacOS/$SHORTCUT_NAME"
 ICON_FILE_PATH="$APP_SHORTCUT_PATH/Contents/Resources/$SHORTCUT_NAME.icns"
 
 rm -rf "$APP_SHORTCUT_PATH"
+# Cleanup existing installations of psneulinkviewer
 rm -rf "$HOME/psyneulinkviewer-darwin-x64/" 
 rm -rf "$DESKTOP_PATH/$SHORTCUT_NAME.app"
-ls -ls
 
 pip uninstall psyneulinkviewer && pip cache purge
 pip install -vv psyneulinkviewer --break-system-packages --use-pep517 && source ~/.bashrc_profile

--- a/package/scripts/mac_installer.sh
+++ b/package/scripts/mac_installer.sh
@@ -27,6 +27,8 @@ rm -rf "$APP_SHORTCUT_PATH"
 rm -rf "$HOME/psyneulinkviewer-darwin-x64/" 
 rm -rf "$DESKTOP_PATH/$SHORTCUT_NAME.app"
 
+ps aux | grep rpc_server | grep -v grep | awk '{print $2}' | xargs kill -9
+
 pip uninstall psyneulinkviewer && pip cache purge
 pip install -vv psyneulinkviewer --break-system-packages --use-pep517 && source ~/.bashrc_profile
 check_last_command
@@ -40,7 +42,6 @@ CONDA_SH=$(find ~ -name conda.sh 2>/dev/null | head -n 1)
 # Write the .command file that launches the app with conda environment
 cat <<EOL > "$COMMAND_FILE_PATH"
 #!/bin/bash
-ps aux | grep rpc_server | grep -v grep | awk '{print $2}' | xargs kill -9
 source ~/.bashrc_profile
 source $CONDA_SH
 conda activate $PSYNEULINK_ENV

--- a/package/scripts/mac_installer.sh
+++ b/package/scripts/mac_installer.sh
@@ -10,10 +10,6 @@ check_last_command () {
     fi
 }
 
-pip uninstall psyneulinkviewer && pip cache purge
-pip install -vv psyneulinkviewer --break-system-packages --use-pep517 && source ~/.bashrc_profile
-check_last_command
-
 # Variables - adjust these for your setup
 APP_PATH="$HOME/psyneulinkviewer-darwin-x64/psyneulinkviewer.app/"  # Replace with the full path to the application
 CONDA_ENV=$PSYNEULINK_ENV              # Replace with your Conda environment name
@@ -26,17 +22,28 @@ APP_SHORTCUT_PATH="$DESKTOP_PATH/$SHORTCUT_NAME.app"
 COMMAND_FILE_PATH="$APP_SHORTCUT_PATH/Contents/MacOS/$SHORTCUT_NAME"
 ICON_FILE_PATH="$APP_SHORTCUT_PATH/Contents/Resources/$SHORTCUT_NAME.icns"
 
-# Create .app structure
 rm -rf "$APP_SHORTCUT_PATH"
+rm -rf "$HOME/psyneulinkviewer-darwin-x64/" 
+rm -rf "$DESKTOP_PATH/$SHORTCUT_NAME.app"
+ls -ls
+
+pip uninstall psyneulinkviewer && pip cache purge
+pip install -vv psyneulinkviewer --break-system-packages --use-pep517 && source ~/.bashrc_profile
+check_last_command
+
+# Create .app structure
 mkdir -p "$APP_SHORTCUT_PATH/Contents/MacOS"
 mkdir -p "$APP_SHORTCUT_PATH/Contents/Resources"
+
+CONDA_SH=$(find ~ -name conda.sh 2>/dev/null | head -n 1)
 
 # Write the .command file that launches the app with conda environment
 cat <<EOL > "$COMMAND_FILE_PATH"
 #!/bin/bash
+ps aux | grep rpc_server | grep -v grep | awk '{print $2}' | xargs kill -9
 source ~/.bashrc_profile
-source ~/miniconda3/etc/profile.d/conda.sh
-conda activate $CONDA_ENV
+source $CONDA_SH
+conda activate $PSYNEULINK_ENV
 open "$APP_PATH"
 EOL
 

--- a/package/scripts/mac_installer.sh
+++ b/package/scripts/mac_installer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 check_last_command () {
     if [[ $? -ne 0 ]]; then
         echo ">>> Please report the output below to support@metacell.us <<<"
@@ -11,10 +12,10 @@ check_last_command () {
 }
 
 # Variables - adjust these for your setup
-APP_PATH="$HOME/psyneulinkviewer-darwin-x64/psyneulinkviewer.app/"  # Replace with the full path to the application
-CONDA_ENV=$PSYNEULINK_ENV              # Replace with your Conda environment name
-ICON_PATH="$HOME/psyneulinkviewer-darwin-x64/psyneulinkviewer.app/Contents/Resources/electron.icns"        # Replace with the full path to your custom icon (should be in .icns format)
-SHORTCUT_NAME="PsyneulinkViewer"         # Name for the desktop shortcut
+APP_PATH="$HOME/psyneulinkviewer-darwin-x64/psyneulinkviewer.app/"
+CONDA_ENV=$PSYNEULINK_ENV
+ICON_PATH="$HOME/psyneulinkviewer-darwin-x64/psyneulinkviewer.app/Contents/Resources/electron.icns" 
+SHORTCUT_NAME="PsyneulinkViewer" 
 
 # Define paths
 DESKTOP_PATH="$HOME/Desktop"
@@ -37,7 +38,27 @@ check_last_command
 mkdir -p "$APP_SHORTCUT_PATH/Contents/MacOS"
 mkdir -p "$APP_SHORTCUT_PATH/Contents/Resources"
 
-CONDA_SH=$(find ~ -name conda.sh 2>/dev/null | head -n 1)
+# Try to find conda.sh, limit search to likely locations
+CONDA_SH=$(find ~ -maxdepth 4 -name conda.sh 2>/dev/null | head -n 1)
+
+echo "Conda.sh found at $CONDA_SH"
+
+# If conda.sh is not found, try the default locations
+if [[ -z "$CONDA_SH" ]]; then
+    if [[ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]]; then
+        CONDA_SH="$HOME/anaconda3/etc/profile.d/conda.sh"
+    elif [[ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]]; then
+        CONDA_SH="$HOME/miniconda3/etc/profile.d/conda.sh"
+    fi
+
+    echo "Conda.sh found at $CONDA_SH"
+fi
+
+# Check if conda.sh was found
+if [[ -z "$CONDA_SH" ]]; then
+    echo "Error: conda.sh not found! Please ensure Conda is installed properly."
+    exit 1
+fi
 
 # Write the .command file that launches the app with conda environment
 cat <<EOL > "$COMMAND_FILE_PATH"


### PR DESCRIPTION
- Checks conda installation path dynamically, and uses this path to activate conda environment prior to opening psyneulinkviewer. Previously the path was expecting always to be in ~/miniconda3, but it's not always the case that's the folder installation
- Cleanup psyneulinkviewer previous versions , and other local folders created durign previous installations
- Kills python server prior to starting application